### PR TITLE
Add `extra_integration_distance_labels`

### DIFF
--- a/config/datasets/kimera_multi_ouster64.yaml
+++ b/config/datasets/kimera_multi_ouster64.yaml
@@ -9,6 +9,8 @@ active_window:
     truncation_distance: 0.75
   tsdf:
     extra_integration_distance: 3.0
+    # NOTE(hlim): '4' is the ground label from ground segmentation
+    extra_integration_distance_labels: [4]
     use_constant_weight: true
     interpolation_method:
       type: adaptive

--- a/config/datasets/kimera_multi_velodyne16.yaml
+++ b/config/datasets/kimera_multi_velodyne16.yaml
@@ -9,6 +9,8 @@ active_window:
     truncation_distance: 0.6
   tsdf:
     extra_integration_distance: 3.0
+    # NOTE(hlim): '4' is the ground label from ground segmentation
+    extra_integration_distance_labels: [4]
     use_constant_weight: true
     interpolation_method:
       type: adaptive


### PR DESCRIPTION
To reflect ground label from Patchwork.

See [this commit](https://github.com/LimHyungTae/patchwork/commit/78fdaaacfdb9b78d7801eca91a8234199db9e20a) in Patchwork repository.

After merging this branch, I'll bump up the version of `hydra_multi_ws` to catch up the recent version.