### PR TITLE
have graph connector default to not overriding active flag

### DIFF
--- a/include/hydra/frontend/graph_connector.h
+++ b/include/hydra/frontend/graph_connector.h
@@ -36,7 +36,6 @@
 #include <spark_dsg/dynamic_scene_graph.h>
 
 #include <map>
-#include <memory>
 #include <set>
 #include <vector>
 
@@ -60,7 +59,7 @@ struct LayerConnector {
     std::vector<ChildLayerConfig> child_layers{
         {spark_dsg::DsgLayers::OBJECTS, true, true}};
     //! Whether or not to force `is_active` to false
-    bool clear_active_flag = true;
+    bool clear_active_flag = false;
   } const config;
 
   explicit LayerConnector(const Config& config);


### PR DESCRIPTION
Changes default setting for `clear_active_flag` so that the mesh indices of all of the objects stay synchronized with the backend. Depending on how Khronos is configured, may mean that all objects from Khronos are considered active in the backend