### PR TITLE
Feature/dcist frontiers

### DIFF
--- a/include/hydra/frontend/frontier_extractor.h
+++ b/include/hydra/frontend/frontier_extractor.h
@@ -66,7 +66,7 @@ class FrontierExtractor {
                        DynamicSceneGraph& graph,
                        const NodeIdSet& active_places);
 
-  void addFrontiers(uint64_t timestamp_ns, DynamicSceneGraph& graph);
+  void addFrontiers(const uint64_t timestamp_ns, DynamicSceneGraph& graph);
 
   void setArchivedPlaces(const std::vector<NodeId>& archived_places);
 

--- a/src/frontend/frontier_extractor.cpp
+++ b/src/frontend/frontier_extractor.cpp
@@ -201,8 +201,8 @@ void processBlock(NearestNodeFinder& finder,
                   SpatialCloud::Ptr archived_cloud) {
   const size_t voxels_per_block = std::pow(tsdf.voxels_per_side, 3);
 
+  const auto tsdf_block = tsdf.getBlockPtr(block_index);
   for (size_t v = 0; v < voxels_per_block; ++v) {
-    const auto tsdf_block = tsdf.getBlockPtr(block_index);
     if (tsdf_block && tsdf_block->getVoxel(v).weight >= 1e-6) {
       // If the voxel has been observed, it's not a frontier
       continue;
@@ -227,7 +227,7 @@ void processBlock(NearestNodeFinder& finder,
       }
       const size_t vn =
           spatial_hash::linearIndexFromVoxelIndex(neighbor, tsdf.voxels_per_side);
-      auto& neighbor_voxel = tsdf_block->getVoxel(vn);
+      const auto& neighbor_voxel = tsdf_block->getVoxel(vn);
       if (neighbor_voxel.weight > 1e-6 && neighbor_voxel.distance > 0.5) {
         found_free_neighbor = true;
       }
@@ -239,7 +239,7 @@ void processBlock(NearestNodeFinder& finder,
     // TODO: if we get free space on the edge of a block that goes into an unallocated
     // block, do we need to add that block to the processing queue?
     if (skip_adding_frontiers) {
-      return;
+      continue;
     }
 
     cloud->points.push_back({center.x(), center.y(), center.z()});
@@ -287,7 +287,7 @@ void FrontierExtractor::computeSparseFrontiers(const SpatialCloud::Ptr cloud,
                     config.point_threshold,
                     finished_frontiers);
 
-  for (auto f : finished_frontiers) {
+  for (const auto& f : finished_frontiers) {
     if (f.size() < config.culling_point_threshold) {
       continue;
     }

--- a/src/frontend/frontier_extractor.cpp
+++ b/src/frontend/frontier_extractor.cpp
@@ -404,6 +404,7 @@ void FrontierExtractor::addFrontiers(const uint64_t timestamp_ns,
     if (tsdf_->hasBlock(nid_bix.second)) {
       graph.removeNode(nid_bix.first);
     } else {
+      graph.getNode(nid_bix.first).attributes<PlaceNodeAttributes>().is_active = false;
       graph.getNode(nid_bix.first).attributes<PlaceNodeAttributes>().active_frontier =
           false;
     }
@@ -426,7 +427,7 @@ void FrontierExtractor::addFrontiers(const uint64_t timestamp_ns,
           attrs->real_place = false;
           attrs->need_cleanup = true;
           attrs->last_update_time_ns = timestamp_ns;
-          attrs->is_active = false;
+          attrs->is_active = true;
           attrs->active_frontier = true;
           graph.emplaceNode(DsgLayers::PLACES, next_node_id_, std::move(attrs));
           graph.insertEdge(place_id, next_node_id_);

--- a/src/frontend/graph_builder.cpp
+++ b/src/frontend/graph_builder.cpp
@@ -535,9 +535,11 @@ void GraphBuilder::updatePlaces(const ActiveWindowOutput& input) {
     std::vector<NodeId> archived_places;
     for (const auto& [node_id, node] :
          dsg_->graph->getLayer(DsgLayers::PLACES).nodes()) {
-      auto& attrs = node->attributes();
+      auto& attrs = node->attributes<PlaceNodeAttributes>();
       const auto prev_active = attrs.is_active;
-      attrs.is_active = active_nodes.count(node_id);
+      if (attrs.real_place) {
+        attrs.is_active = active_nodes.count(node_id);
+      }
       if (prev_active && !attrs.is_active) {
         archived_places.push_back(node_id);
       }


### PR DESCRIPTION
The frontiers on develop don't really work. I think at some point these commits got lost in porting the frontiers from ROS 1 / the old active-dsg code. We shouldn't merge this until I validate it a little more, but seems to build/run and frontiers look much cleaner. Putting up this PR now so that we don't lose track of this code. 

The changes simplify the frontier logic greatly -- the frontend 3D places aren't used for keeping track of which frontiers to generate anymore. 