### PR TITLE
Feature/gradient traversability

### DIFF
--- a/include/hydra/places/traversability_estimator.h
+++ b/include/hydra/places/traversability_estimator.h
@@ -137,7 +137,7 @@ class GradientTraversabilityEstimator : public TraversabilityEstimator {
     float height_below = 1.0f;
 
     //! @brief Minimum TSDF weight to consider voxel observed.
-    float min_weight = 1e-6f;
+    float min_weight = 1.0e-6f;
 
     //! @brief Minimum confidence for a voxel to be considered observed.
     float min_confidence = 0.5f;

--- a/include/hydra/places/traversability_estimator.h
+++ b/include/hydra/places/traversability_estimator.h
@@ -173,7 +173,8 @@ class GradientTraversabilityEstimator : public TraversabilityEstimator {
   // Helper functions.
   BlockIndexSet get2DBlockIndices(const BlockIndices& blocks) const;
 
-  std::optional<float> extractSurfaceHeight(const BlockIndex& global_2d_index,
+  std::optional<float> extractSurfaceHeight(const BlockIndex& block_2d_index,
+                                            const VoxelIndex& local_2d,
                                             float robot_z) const;
 
   float computeHorizontalDistance(const Index2D& offset) const;

--- a/include/hydra/places/traversability_estimator.h
+++ b/include/hydra/places/traversability_estimator.h
@@ -116,4 +116,75 @@ class HeightTraversabilityEstimator : public TraversabilityEstimator {
 
 void declare_config(HeightTraversabilityEstimator::Config& config);
 
+/**
+ * @brief Traversability estimator based on local terrain gradient.
+ * @note Computes traversability from maximum absolute height gradient in 8-way
+ * connected neighborhood. Captures both positive obstacles (steps, rocks) and negative
+ * obstacles (holes, cliffs).
+ */
+class GradientTraversabilityEstimator : public TraversabilityEstimator {
+ public:
+  struct Config {
+    //! @brief Maximum traversable gradient (m/m). Gradient >= threshold →
+    //! traversability = 0. Gradient = 0 → traversability = 1. Linear interpolation
+    //! between.
+    float gradient_threshold = 0.5f;
+
+    //! @brief The height above the robot body to scan for surfaces in meters.
+    float height_above = 0.3f;
+
+    //! @brief The height below the robot body to scan for surfaces in meters.
+    float height_below = 1.0f;
+
+    //! @brief Minimum TSDF weight to consider voxel observed.
+    float min_weight = 1e-6f;
+
+    //! @brief TSDF distance threshold for surface detection (multiples of voxel_size).
+    //! A voxel is on surface if abs(distance) < voxel_size * threshold.
+    float surface_distance_threshold = 1.0f;
+
+    //! @brief Minimum confidence for a voxel to be considered observed.
+    float min_confidence = 0.5f;
+
+    //! @brief Minimum traversability for a voxel to be considered traversable.
+    float min_traversability = 0.5f;
+
+    //! @brief If true, mark voxels as intraversable if they do not meet the
+    //! min_traversability threshold, even if the confidence is below min_confidence. If
+    //! false, mark these voxels as unknown instead.
+    bool pessimistic = true;
+  };
+
+  GradientTraversabilityEstimator(const Config& config);
+  ~GradientTraversabilityEstimator() override = default;
+
+  void updateTraversability(const ActiveWindowOutput& msg) override;
+
+  const Config config;
+
+ protected:
+  TsdfLayer::Ptr tsdf_layer_;
+
+  // Processing steps (reuse updateTsdf from HeightTraversabilityEstimator).
+  void updateTsdf(const ActiveWindowOutput& msg);
+  void computeTraversability(const ActiveWindowOutput& msg);
+  void classifyTraversabilityVoxel(TraversabilityVoxel& voxel) const;
+
+  // Helper functions.
+  BlockIndexSet get2DBlockIndices(const BlockIndices& blocks) const;
+
+  std::optional<float> extractSurfaceHeight(const BlockIndex& global_2d_index,
+                                            float robot_z) const;
+
+  float computeHorizontalDistance(const Index2D& offset) const;
+
+  float computeTraversabilityFromGradient(float gradient) const;
+
+ private:
+  // 8-way neighbor offsets.
+  static const std::array<Index2D, 8> kNeighborOffsets;
+};
+
+void declare_config(GradientTraversabilityEstimator::Config& config);
+
 }  // namespace hydra::places

--- a/include/hydra/places/traversability_estimator.h
+++ b/include/hydra/places/traversability_estimator.h
@@ -139,10 +139,6 @@ class GradientTraversabilityEstimator : public TraversabilityEstimator {
     //! @brief Minimum TSDF weight to consider voxel observed.
     float min_weight = 1e-6f;
 
-    //! @brief TSDF distance threshold for surface detection (multiples of voxel_size).
-    //! A voxel is on surface if abs(distance) < voxel_size * threshold.
-    float surface_distance_threshold = 1.0f;
-
     //! @brief Minimum confidence for a voxel to be considered observed.
     float min_confidence = 0.5f;
 

--- a/include/hydra/places/traversability_estimator.h
+++ b/include/hydra/places/traversability_estimator.h
@@ -149,6 +149,10 @@ class GradientTraversabilityEstimator : public TraversabilityEstimator {
     //! min_traversability threshold, even if the confidence is below min_confidence. If
     //! false, mark these voxels as unknown instead.
     bool pessimistic = true;
+
+    //! @brief If true, smooth the height map with a box filter before computing
+    //! gradients, reducing the ripple artifact caused by projective TSDF radial bias.
+    bool smoothing = true;
   };
 
   GradientTraversabilityEstimator(const Config& config);

--- a/src/places/traversability_estimator.cpp
+++ b/src/places/traversability_estimator.cpp
@@ -281,7 +281,7 @@ void GradientTraversabilityEstimator::updateTsdf(const ActiveWindowOutput& msg) 
 
 void GradientTraversabilityEstimator::computeTraversability(
     const ActiveWindowOutput& msg) {
-  const BlockIndexSet updated_blocks_2d =
+  const auto updated_blocks_2d =
       get2DBlockIndices(msg.map().getTsdfLayer().allocatedBlockIndices());
   const float robot_z = msg.world_t_body.z();
   const int voxels_per_side = tsdf_layer_->voxels_per_side;
@@ -290,13 +290,10 @@ void GradientTraversabilityEstimator::computeTraversability(
   // previously-processed traversability blocks), so newly-seen areas are included.
   Index2DMap<float> height_map;
 
-  const BlockIndexSet all_blocks_2d =
-      get2DBlockIndices(tsdf_layer_->allocatedBlockIndices());
+  const auto all_blocks_2d = get2DBlockIndices(tsdf_layer_->allocatedBlockIndices());
   for (const auto& block_idx_2d : all_blocks_2d) {
     for (int x = 0; x < voxels_per_side; ++x) {
       for (int y = 0; y < voxels_per_side; ++y) {
-        // Extract surface height using block/local indices directly to avoid the
-        // signed/unsigned division bug in spatial_hash::blockIndexFromGlobalIndex.
         std::optional<float> surface_height =
             extractSurfaceHeight(block_idx_2d, VoxelIndex(x, y, 0), robot_z);
 

--- a/src/places/traversability_estimator.cpp
+++ b/src/places/traversability_estimator.cpp
@@ -222,7 +222,6 @@ void declare_config(GradientTraversabilityEstimator::Config& config) {
   field(config.height_above, "height_above", "m");
   field(config.height_below, "height_below", "m");
   field(config.min_weight, "min_weight");
-  field(config.surface_distance_threshold, "surface_distance_threshold");
   field(config.min_confidence, "min_confidence");
   field(config.min_traversability, "min_traversability");
   field(config.pessimistic, "pessimistic");
@@ -401,7 +400,6 @@ std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
   // to avoid the signed/unsigned division bug in spatial_hash::blockIndexFromGlobalIndex,
   // which corrupts getVoxelPtr lookups for any negative world coordinate.
   const float voxel_size = tsdf_layer_->voxel_size;
-  const float surface_threshold = config.surface_distance_threshold * voxel_size;
   const int vps = static_cast<int>(tsdf_layer_->voxels_per_side);
 
   const VoxelKey min_key =
@@ -425,7 +423,8 @@ std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
       if (voxel.weight < config.min_weight) {
         continue;
       }
-      if (std::abs(voxel.distance) < surface_threshold) {
+
+      if (voxel.distance < voxel_size) {
         const VoxelKey key(BlockIndex(block_2d_index.x(), block_2d_index.y(), block_z),
                            VoxelIndex(local_2d.x(), local_2d.y(), z));
         return tsdf_layer_->getVoxelPosition(key).z();

--- a/src/places/traversability_estimator.cpp
+++ b/src/places/traversability_estimator.cpp
@@ -286,34 +286,34 @@ void GradientTraversabilityEstimator::computeTraversability(
   const float robot_z = msg.world_t_body.z();
   const int voxels_per_side = tsdf_layer_->voxels_per_side;
 
-  // PASS 1: Extract all surface heights into a 2D map.
+  // PASS 1: Extract heights from ALL currently allocated TSDF blocks (not just
+  // previously-processed traversability blocks), so newly-seen areas are included.
   Index2DMap<float> height_map;
 
-  for (auto& block_idx_2d : updated_blocks_2d) {
-    auto& trav_block =
-        traversability_layer_->allocateBlock(block_idx_2d, voxels_per_side);
-    trav_block.reset();
-    trav_block.updated = true;
-
+  const BlockIndexSet all_blocks_2d = get2DBlockIndices(tsdf_layer_->allocatedBlockIndices());
+  for (const auto& block_idx_2d : all_blocks_2d) {
     for (int x = 0; x < voxels_per_side; ++x) {
       for (int y = 0; y < voxels_per_side; ++y) {
-        const BlockIndex global_2d = trav_block.globalFromLocalIndex(Index2D(x, y));
-
-        // Extract surface height.
-        std::optional<float> surface_height = extractSurfaceHeight(global_2d, robot_z);
+        // Extract surface height using block/local indices directly to avoid the
+        // signed/unsigned division bug in spatial_hash::blockIndexFromGlobalIndex.
+        std::optional<float> surface_height =
+            extractSurfaceHeight(block_idx_2d, VoxelIndex(x, y, 0), robot_z);
 
         if (surface_height) {
-          // Store as 2D index (x, y) → height.
-          height_map[Index2D(global_2d.x(), global_2d.y())] = *surface_height;
+          const Index2D key(block_idx_2d.x() * voxels_per_side + x,
+                            block_idx_2d.y() * voxels_per_side + y);
+          height_map[key] = *surface_height;
         }
       }
     }
   }
 
-  // PASS 2: Compute gradients and traversability using precomputed heights.
+  // PASS 2: Update ONLY the blocks that were updated in TSDF.
   for (auto& block_idx_2d : updated_blocks_2d) {
     auto& trav_block =
         traversability_layer_->allocateBlock(block_idx_2d, voxels_per_side);
+    trav_block.reset();  // Reset now, in Pass 2.
+    trav_block.updated = true;
 
     for (int x = 0; x < voxels_per_side; ++x) {
       for (int y = 0; y < voxels_per_side; ++y) {
@@ -395,35 +395,42 @@ BlockIndexSet GradientTraversabilityEstimator::get2DBlockIndices(
 }
 
 std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
-    const BlockIndex& global_2d_index, float robot_z) const {
-  // Find the first occupied voxel in the vertical column from top to bottom. 
+    const BlockIndex& block_2d_index, const VoxelIndex& local_2d, float robot_z) const {
+  // Find the highest surface voxel in the vertical column by scanning top to bottom.
+  // Uses block/local index access directly (same pattern as HeightTraversabilityEstimator)
+  // to avoid the signed/unsigned division bug in spatial_hash::blockIndexFromGlobalIndex,
+  // which corrupts getVoxelPtr lookups for any negative world coordinate.
   const float voxel_size = tsdf_layer_->voxel_size;
   const float surface_threshold = config.surface_distance_threshold * voxel_size;
+  const int vps = static_cast<int>(tsdf_layer_->voxels_per_side);
 
-  // Compute Z search range (same as HeightTraversabilityEstimator).
-  const Point min_point(0, 0, robot_z - config.height_below);
-  const Point max_point(0, 0, robot_z + config.height_above);
+  const VoxelKey min_key =
+      tsdf_layer_->getVoxelKey(Point(0, 0, robot_z - config.height_below));
+  const VoxelKey max_key =
+      tsdf_layer_->getVoxelKey(Point(0, 0, robot_z + config.height_above));
 
-  const BlockIndex min_global = tsdf_layer_->getGlobalVoxelIndex(min_point);
-  const BlockIndex max_global = tsdf_layer_->getGlobalVoxelIndex(max_point);
+  for (int block_z = max_key.first.z(); block_z >= min_key.first.z(); --block_z) {
+    const auto tsdf_block = tsdf_layer_->getBlockPtr(
+        BlockIndex(block_2d_index.x(), block_2d_index.y(), block_z));
+    if (!tsdf_block) {
+      continue;
+    }
 
-  // Scan the vertical range for surface.
-  for (int z = max_global.z(); z >= min_global.z(); --z) {
-    const BlockIndex global_idx(global_2d_index.x(), global_2d_index.y(), z);
-    const TsdfVoxel* voxel = tsdf_layer_->getVoxelPtr(global_idx);
+    const int min_voxel_z = block_z == min_key.first.z() ? min_key.second.z() : 0;
+    const int max_voxel_z = block_z == max_key.first.z() ? max_key.second.z() : vps - 1;
 
-    if (!voxel) continue;
-    if (voxel->weight < config.min_weight) continue;
-
-    // Check if on surface.
-    // if (std::abs(voxel->distance) < surface_threshold) {
-    //   const Point voxel_pos = tsdf_layer_->getVoxelPosition(global_idx);
-    //   return voxel_pos.z();  // Return just the height.
-    // }
-
-    // treat any occupancy as suface if voxel is observed and occupied. 
-    const Point voxel_pos = tsdf_layer_->getVoxelPosition(global_idx);
-    return voxel_pos.z();
+    for (int z = max_voxel_z; z >= min_voxel_z; --z) {
+      const auto& voxel =
+          tsdf_block->getVoxel(VoxelIndex(local_2d.x(), local_2d.y(), z));
+      if (voxel.weight < config.min_weight) {
+        continue;
+      }
+      if (std::abs(voxel.distance) < surface_threshold) {
+        const VoxelKey key(BlockIndex(block_2d_index.x(), block_2d_index.y(), block_z),
+                           VoxelIndex(local_2d.x(), local_2d.y(), z));
+        return tsdf_layer_->getVoxelPosition(key).z();
+      }
+    }
   }
 
   return std::nullopt;

--- a/src/places/traversability_estimator.cpp
+++ b/src/places/traversability_estimator.cpp
@@ -225,6 +225,7 @@ void declare_config(GradientTraversabilityEstimator::Config& config) {
   field(config.min_confidence, "min_confidence");
   field(config.min_traversability, "min_traversability");
   field(config.pessimistic, "pessimistic");
+  field(config.smoothing, "smoothing");
 
   checkCondition(config.gradient_threshold > 0.0f,
                  "gradient_threshold must be positive");
@@ -289,7 +290,8 @@ void GradientTraversabilityEstimator::computeTraversability(
   // previously-processed traversability blocks), so newly-seen areas are included.
   Index2DMap<float> height_map;
 
-  const BlockIndexSet all_blocks_2d = get2DBlockIndices(tsdf_layer_->allocatedBlockIndices());
+  const BlockIndexSet all_blocks_2d =
+      get2DBlockIndices(tsdf_layer_->allocatedBlockIndices());
   for (const auto& block_idx_2d : all_blocks_2d) {
     for (int x = 0; x < voxels_per_side; ++x) {
       for (int y = 0; y < voxels_per_side; ++y) {
@@ -307,6 +309,29 @@ void GradientTraversabilityEstimator::computeTraversability(
     }
   }
 
+  // Optionally smooth height map to remove projective TSDF radial bias (ripple
+  // artifact). For each voxel, replace its height with the average of itself and
+  // observed neighbors.
+  Index2DMap<float> smoothed_height_map;
+  if (config.smoothing) {
+    smoothed_height_map.reserve(height_map.size());
+    for (const auto& [center_idx, center_height] : height_map) {
+      float height_sum = center_height;
+      int count = 1;
+      for (const auto& offset : kNeighborOffsets) {
+        auto it = height_map.find(
+            Index2D(center_idx.x() + offset.x(), center_idx.y() + offset.y()));
+        if (it != height_map.end()) {
+          height_sum += it->second;
+          count++;
+        }
+      }
+      smoothed_height_map[center_idx] = height_sum / count;
+    }
+  }
+  const Index2DMap<float>& grad_height_map =
+      config.smoothing ? smoothed_height_map : height_map;
+
   // PASS 2: Update ONLY the blocks that were updated in TSDF.
   for (auto& block_idx_2d : updated_blocks_2d) {
     auto& trav_block =
@@ -321,8 +346,8 @@ void GradientTraversabilityEstimator::computeTraversability(
         const Index2D center_idx(global_2d.x(), global_2d.y());
 
         // Check if center has surface.
-        auto center_it = height_map.find(center_idx);
-        if (center_it == height_map.end()) {
+        auto center_it = grad_height_map.find(center_idx);
+        if (center_it == grad_height_map.end()) {
           trav_voxel.confidence = 0.0f;
           trav_voxel.traversability = 0.0f;
           classifyTraversabilityVoxel(trav_voxel);
@@ -331,19 +356,19 @@ void GradientTraversabilityEstimator::computeTraversability(
 
         const float center_height = center_it->second;
 
-        // Compute max gradient over 8 neighbors.
-        float max_gradient = 0.0f;
+        // Compute mean gradient over observed neighbors. Skip missing neighbors —
+        // the confidence field already captures partial coverage; treating missing
+        // neighbors as infinite gradient makes boundary voxels intraversable even
+        // on flat terrain, and prevents intermediate (yellow) traversability values.
+        float gradient_sum = 0.0f;
         int num_neighbors_observed = 0;
 
         for (const auto& offset : kNeighborOffsets) {
           const Index2D neighbor_idx(center_idx.x() + offset.x(),
                                      center_idx.y() + offset.y());
 
-          auto neighbor_it = height_map.find(neighbor_idx);
-
-          if (neighbor_it == height_map.end()) {
-            // Missing neighbor = infinite gradient (obstacle).
-            max_gradient = std::numeric_limits<float>::max();
+          auto neighbor_it = grad_height_map.find(neighbor_idx);
+          if (neighbor_it == grad_height_map.end()) {
             continue;
           }
 
@@ -351,12 +376,12 @@ void GradientTraversabilityEstimator::computeTraversability(
 
           const float height_diff = std::abs(neighbor_it->second - center_height);
           const float horiz_dist = computeHorizontalDistance(offset);
-          const float gradient = height_diff / horiz_dist;
-
-          max_gradient = std::max(max_gradient, gradient);
+          gradient_sum += height_diff / horiz_dist;
         }
 
-        trav_voxel.traversability = computeTraversabilityFromGradient(max_gradient);
+        const float mean_gradient =
+            num_neighbors_observed > 0 ? gradient_sum / num_neighbors_observed : 0.0f;
+        trav_voxel.traversability = computeTraversabilityFromGradient(mean_gradient);
         trav_voxel.confidence = num_neighbors_observed / 8.0f;
 
         classifyTraversabilityVoxel(trav_voxel);
@@ -396,9 +421,10 @@ BlockIndexSet GradientTraversabilityEstimator::get2DBlockIndices(
 std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
     const BlockIndex& block_2d_index, const VoxelIndex& local_2d, float robot_z) const {
   // Find the highest surface voxel in the vertical column by scanning top to bottom.
-  // Uses block/local index access directly (same pattern as HeightTraversabilityEstimator)
-  // to avoid the signed/unsigned division bug in spatial_hash::blockIndexFromGlobalIndex,
-  // which corrupts getVoxelPtr lookups for any negative world coordinate.
+  // Uses block/local index access directly (same pattern as
+  // HeightTraversabilityEstimator) to avoid the signed/unsigned division bug in
+  // spatial_hash::blockIndexFromGlobalIndex, which corrupts getVoxelPtr lookups for any
+  // negative world coordinate.
   const float voxel_size = tsdf_layer_->voxel_size;
   const int vps = static_cast<int>(tsdf_layer_->voxels_per_side);
 

--- a/src/places/traversability_estimator.cpp
+++ b/src/places/traversability_estimator.cpp
@@ -45,9 +45,26 @@ static const auto registration_ =
                                    HeightTraversabilityEstimator,
                                    HeightTraversabilityEstimator::Config>(
         "HeightTraversabilityEstimator");
-}
+
+static const auto gradient_registration_ =
+    config::RegistrationWithConfig<TraversabilityEstimator,
+                                   GradientTraversabilityEstimator,
+                                   GradientTraversabilityEstimator::Config>(
+        "GradientTraversabilityEstimator");
+}  // namespace
 
 using spark_dsg::TraversabilityState;
+
+const std::array<Index2D, 8> GradientTraversabilityEstimator::kNeighborOffsets = {{
+    {0, -1},   // bottom
+    {-1, 0},   // left
+    {0, 1},    // top
+    {1, 0},    // right
+    {-1, -1},  // bottom-left
+    {-1, 1},   // top-left
+    {1, 1},    // top-right
+    {1, -1}    // bottom-right
+}};
 
 void declare_config(HeightTraversabilityEstimator::Config& config) {
   using namespace config;
@@ -196,6 +213,238 @@ BlockIndexSet HeightTraversabilityEstimator::get2DBlockIndices(
     block_indices.emplace(BlockIndex(block.x(), block.y(), 0));
   }
   return block_indices;
+}
+
+void declare_config(GradientTraversabilityEstimator::Config& config) {
+  using namespace config;
+  name("GradientTraversabilityEstimator::Config");
+  field(config.gradient_threshold, "gradient_threshold");
+  field(config.height_above, "height_above", "m");
+  field(config.height_below, "height_below", "m");
+  field(config.min_weight, "min_weight");
+  field(config.surface_distance_threshold, "surface_distance_threshold");
+  field(config.min_confidence, "min_confidence");
+  field(config.min_traversability, "min_traversability");
+  field(config.pessimistic, "pessimistic");
+
+  checkCondition(config.gradient_threshold > 0.0f,
+                 "gradient_threshold must be positive");
+  checkCondition(config.height_above >= -config.height_below,
+                 "'height_above' and 'height_below' don't span any volume");
+  checkInRange(config.min_confidence, 0.0f, 1.0f, "min_confidence");
+  checkInRange(config.min_traversability, 0.0f, 1.0f, "min_traversability");
+}
+
+GradientTraversabilityEstimator::GradientTraversabilityEstimator(const Config& config)
+    : config(config::checkValid(config)) {}
+
+void GradientTraversabilityEstimator::updateTraversability(
+    const ActiveWindowOutput& msg) {
+  updateTsdf(msg);
+  computeTraversability(msg);
+}
+
+void GradientTraversabilityEstimator::updateTsdf(const ActiveWindowOutput& msg) {
+  // Initialize the TSDF if this is the first call.
+  if (!tsdf_layer_) {
+    const auto& map_config = msg.map().config;
+    tsdf_layer_ =
+        std::make_shared<TsdfLayer>(map_config.voxel_size, map_config.voxels_per_side);
+    traversability_layer_ = std::make_unique<TraversabilityLayer>(
+        map_config.voxel_size, map_config.voxels_per_side);
+  }
+
+  // Erase archived blocks.
+  tsdf_layer_->removeBlocks(msg.archived_mesh_indices);
+  const BlockIndexSet blocks_2d =
+      get2DBlockIndices(tsdf_layer_->allocatedBlockIndices());
+  for (const auto& block_index : traversability_layer_->allocatedBlockIndices()) {
+    if (!blocks_2d.count(block_index)) {
+      traversability_layer_->removeBlock(block_index);
+    }
+  }
+
+  // Copy in all updated blocks. These are mutually exclusive with the updated blocks.
+  for (const auto& block : msg.map().getTsdfLayer()) {
+    tsdf_layer_->allocateBlock(block.index) = block;
+    if (!block.updated) {
+      LOG(WARNING) << "TSDF block " << block.index.transpose()
+                   << " is not marked as updated, but it was copied from the map.";
+    }
+  }
+
+  // Reset the updated flag.
+  for (auto& block : *traversability_layer_) {
+    block.updated = false;
+  }
+}
+
+void GradientTraversabilityEstimator::computeTraversability(
+    const ActiveWindowOutput& msg) {
+  const BlockIndexSet updated_blocks_2d =
+      get2DBlockIndices(msg.map().getTsdfLayer().allocatedBlockIndices());
+  const float robot_z = msg.world_t_body.z();
+  const int voxels_per_side = tsdf_layer_->voxels_per_side;
+
+  // PASS 1: Extract all surface heights into a 2D map.
+  Index2DMap<float> height_map;
+
+  for (auto& block_idx_2d : updated_blocks_2d) {
+    auto& trav_block =
+        traversability_layer_->allocateBlock(block_idx_2d, voxels_per_side);
+    trav_block.reset();
+    trav_block.updated = true;
+
+    for (int x = 0; x < voxels_per_side; ++x) {
+      for (int y = 0; y < voxels_per_side; ++y) {
+        const BlockIndex global_2d = trav_block.globalFromLocalIndex(Index2D(x, y));
+
+        // Extract surface height.
+        std::optional<float> surface_height = extractSurfaceHeight(global_2d, robot_z);
+
+        if (surface_height) {
+          // Store as 2D index (x, y) → height.
+          height_map[Index2D(global_2d.x(), global_2d.y())] = *surface_height;
+        }
+      }
+    }
+  }
+
+  // PASS 2: Compute gradients and traversability using precomputed heights.
+  for (auto& block_idx_2d : updated_blocks_2d) {
+    auto& trav_block =
+        traversability_layer_->allocateBlock(block_idx_2d, voxels_per_side);
+
+    for (int x = 0; x < voxels_per_side; ++x) {
+      for (int y = 0; y < voxels_per_side; ++y) {
+        auto& trav_voxel = trav_block.voxel(x, y);
+        const BlockIndex global_2d = trav_block.globalFromLocalIndex(Index2D(x, y));
+        const Index2D center_idx(global_2d.x(), global_2d.y());
+
+        // Check if center has surface.
+        auto center_it = height_map.find(center_idx);
+        if (center_it == height_map.end()) {
+          trav_voxel.confidence = 0.0f;
+          trav_voxel.traversability = 0.0f;
+          classifyTraversabilityVoxel(trav_voxel);
+          continue;
+        }
+
+        const float center_height = center_it->second;
+
+        // Compute max gradient over 8 neighbors.
+        float max_gradient = 0.0f;
+        int num_neighbors_observed = 0;
+
+        for (const auto& offset : kNeighborOffsets) {
+          const Index2D neighbor_idx(center_idx.x() + offset.x(),
+                                     center_idx.y() + offset.y());
+
+          auto neighbor_it = height_map.find(neighbor_idx);
+
+          if (neighbor_it == height_map.end()) {
+            // Missing neighbor = infinite gradient (obstacle).
+            max_gradient = std::numeric_limits<float>::max();
+            continue;
+          }
+
+          num_neighbors_observed++;
+
+          const float height_diff = std::abs(neighbor_it->second - center_height);
+          const float horiz_dist = computeHorizontalDistance(offset);
+          const float gradient = height_diff / horiz_dist;
+
+          max_gradient = std::max(max_gradient, gradient);
+        }
+
+        trav_voxel.traversability = computeTraversabilityFromGradient(max_gradient);
+        trav_voxel.confidence = num_neighbors_observed / 8.0f;
+
+        classifyTraversabilityVoxel(trav_voxel);
+      }
+    }
+  }
+}
+
+void GradientTraversabilityEstimator::classifyTraversabilityVoxel(
+    TraversabilityVoxel& voxel) const {
+  if (voxel.confidence <= 0.0f) {
+    voxel.state = TraversabilityState::UNKNOWN;
+    return;
+  }
+  if (voxel.confidence >= config.min_confidence) {
+    if (voxel.traversability >= config.min_traversability) {
+      voxel.state = TraversabilityState::TRAVERSABLE;
+    } else {
+      voxel.state = TraversabilityState::INTRAVERSABLE;
+    }
+  } else if (config.pessimistic && voxel.traversability < config.min_traversability) {
+    voxel.state = TraversabilityState::INTRAVERSABLE;
+  } else {
+    voxel.state = TraversabilityState::UNKNOWN;
+  }
+}
+
+BlockIndexSet GradientTraversabilityEstimator::get2DBlockIndices(
+    const BlockIndices& blocks) const {
+  BlockIndexSet block_indices;
+  for (const auto& block : blocks) {
+    block_indices.emplace(BlockIndex(block.x(), block.y(), 0));
+  }
+  return block_indices;
+}
+
+std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
+    const BlockIndex& global_2d_index, float robot_z) const {
+  const float voxel_size = tsdf_layer_->voxel_size;
+  const float surface_threshold = config.surface_distance_threshold * voxel_size;
+
+  // Compute Z search range (same as HeightTraversabilityEstimator).
+  const Point min_point(0, 0, robot_z - config.height_below);
+  const Point max_point(0, 0, robot_z + config.height_above);
+
+  const BlockIndex min_global = tsdf_layer_->getGlobalVoxelIndex(min_point);
+  const BlockIndex max_global = tsdf_layer_->getGlobalVoxelIndex(max_point);
+
+  // Scan the vertical range for surface.
+  for (int z = max_global.z(); z >= min_global.z(); --z) {
+    const BlockIndex global_idx(global_2d_index.x(), global_2d_index.y(), z);
+    const TsdfVoxel* voxel = tsdf_layer_->getVoxelPtr(global_idx);
+
+    if (!voxel) continue;
+    if (voxel->weight < config.min_weight) continue;
+
+    // Check if on surface.
+    if (std::abs(voxel->distance) < surface_threshold) {
+      const Point voxel_pos = tsdf_layer_->getVoxelPosition(global_idx);
+      return voxel_pos.z();  // Return just the height.
+    }
+  }
+
+  return std::nullopt;
+}
+
+float GradientTraversabilityEstimator::computeHorizontalDistance(
+    const Index2D& offset) const {
+  const float voxel_size = tsdf_layer_->voxel_size;
+
+  // Diagonal: sqrt(2) * voxel_size.
+  if (offset.x() != 0 && offset.y() != 0) {
+    return voxel_size * std::sqrt(2.0f);
+  }
+
+  // Cardinal: voxel_size.
+  return voxel_size;
+}
+
+float GradientTraversabilityEstimator::computeTraversabilityFromGradient(
+    float gradient) const {
+  if (gradient >= config.gradient_threshold) {
+    return 0.0f;  // Intraversable.
+  }
+
+  // Linear interpolation: 1.0 at gradient=0, 0.0 at gradient=threshold.
+  return 1.0f - (gradient / config.gradient_threshold);
 }
 
 }  // namespace hydra::places

--- a/src/places/traversability_estimator.cpp
+++ b/src/places/traversability_estimator.cpp
@@ -396,6 +396,7 @@ BlockIndexSet GradientTraversabilityEstimator::get2DBlockIndices(
 
 std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
     const BlockIndex& global_2d_index, float robot_z) const {
+  // Find the first occupied voxel in the vertical column from top to bottom. 
   const float voxel_size = tsdf_layer_->voxel_size;
   const float surface_threshold = config.surface_distance_threshold * voxel_size;
 
@@ -415,10 +416,14 @@ std::optional<float> GradientTraversabilityEstimator::extractSurfaceHeight(
     if (voxel->weight < config.min_weight) continue;
 
     // Check if on surface.
-    if (std::abs(voxel->distance) < surface_threshold) {
-      const Point voxel_pos = tsdf_layer_->getVoxelPosition(global_idx);
-      return voxel_pos.z();  // Return just the height.
-    }
+    // if (std::abs(voxel->distance) < surface_threshold) {
+    //   const Point voxel_pos = tsdf_layer_->getVoxelPosition(global_idx);
+    //   return voxel_pos.z();  // Return just the height.
+    // }
+
+    // treat any occupancy as suface if voxel is observed and occupied. 
+    const Point voxel_pos = tsdf_layer_->getVoxelPosition(global_idx);
+    return voxel_pos.z();
   }
 
   return std::nullopt;


### PR DESCRIPTION
Want to get the pr setup sooner rather than later to discuss potential improvement (and bugfix) of the current method. 

Compute traversability based on the local height gradient, in the hope that it will fix the potential issue of HeightTraversability when encountering ramps. Try to serve as a backup for DCIST. 

The overall idea is that 
1. Get a 2D height map by finding a surface from top to bottom within a specified height range (expecting the floor in this range)
2. (Optional) Perform smoothing for noisy camera measurement and TSDF value
3. For every 3x3 local area, compute a mean gradient relative to the center cell 
4. Thresholding the gradient value for traversability (0-1), calculate 
5. Traversability classification 

Tested on Pennovation bag (slam_medium/hamilton) and an old green building bag with the following parameters. 
```yaml
type: GradientTraversabilityEstimator
      gradient_threshold: 0.5
      height_above: 0.3
      height_below: 1.0
      min_confidence: 0.5
      min_traversability: 0.1 # gradient below 0.45 is traversable
      pessimistic: true
      smoothing: true
```

> NOTE: still have several unsure things about the implementation 
> 1. The gradient value is sensitive. On the edge of different terrain, it might produce a higher gradient even if it seems flat
> 2. Need to set the threshold to a relatively large value for the traversability layer to be sane. (Ideally, spot can traverse height difference below ~0.3, but setting it to 0.3 will generate an arbitrary intraversable voxel on some nearly flat surface)