### PR TITLE
fix(backend): deform khronos object pose and stamp nodes by observation time

### DIFF
--- a/include/hydra/backend/deformation_interpolator.h
+++ b/include/hydra/backend/deformation_interpolator.h
@@ -45,6 +45,10 @@ struct NodeCache {
     NodeId id;
     uint64_t timestamp;
     Eigen::Vector3f init_pos;
+    //! Original (odometric) bounding box, INVALID if the node has none. Cached so
+    //! the deform callback can transform a fresh copy each spin rather than
+    //! mutating the box in place (which would compound on archived nodes).
+    spark_dsg::BoundingBox init_bbox;
   };
 
   Entry* add(NodeId node, const NodeAttributes& attrs);

--- a/include/hydra/backend/deformation_interpolator.h
+++ b/include/hydra/backend/deformation_interpolator.h
@@ -34,21 +34,22 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 
-#include <memory>
-
 #include "hydra/backend/update_functions.h"
 
 namespace hydra {
 
 struct NodeCache {
   struct Entry {
+    //! Node entry ID
     NodeId id;
+    //! Associated update timestamp
     uint64_t timestamp;
+    //! Odometric node position
     Eigen::Vector3f init_pos;
-    //! Original (odometric) bounding box, INVALID if the node has none. Cached so
-    //! the deform callback can transform a fresh copy each spin rather than
-    //! mutating the box in place (which would compound on archived nodes).
+    //! Odometric bounding box for node
     spark_dsg::BoundingBox init_bbox;
+
+    void update(NodeAttributes& attrs, const Eigen::Isometry3d& transform) const;
   };
 
   Entry* add(NodeId node, const NodeAttributes& attrs);

--- a/src/backend/deformation_interpolator.cpp
+++ b/src/backend/deformation_interpolator.cpp
@@ -193,8 +193,13 @@ void DeformationInterpolator::interpolate(const DynamicSceneGraph& unmerged,
 
       auto node_ptr = dsg.findNode(entry->id);
       if (node_ptr) {
-        // move position + bounding box + orientation)
-        node_ptr->attributes().transform(transform);
+        // Reset to the cached original position before applying the transform so
+        // repeated deformation of an archived node stays idempotent (otherwise the
+        // transform compounds across loop-closure spins). transform() also moves
+        // the bounding box + orientation.
+        auto& dst = node_ptr->attributes();
+        dst.position = entry->init_pos.cast<double>();
+        dst.transform(transform);
       }
     };
 

--- a/src/backend/deformation_interpolator.cpp
+++ b/src/backend/deformation_interpolator.cpp
@@ -87,9 +87,7 @@ NodeCache::Entry* NodeCache::add(NodeId node_id, const NodeAttributes& attrs) {
   if (iter == nodes.end()) {
     return &nodes
                 .emplace(node_id,
-                         Entry{node_id,
-                               timestamp_ns,
-                               attrs.position.cast<float>()})
+                         Entry{node_id, timestamp_ns, attrs.position.cast<float>()})
                 .first->second;
   }
 
@@ -195,9 +193,7 @@ void DeformationInterpolator::interpolate(const DynamicSceneGraph& unmerged,
 
       auto node_ptr = dsg.findNode(entry->id);
       if (node_ptr) {
-        // move the full pose (position + bounding box + orientation), not just
-        // position; dsg holds the frontend-original this cycle so this matches
-        // new_pos for the position component
+        // move position + bounding box + orientation)
         node_ptr->attributes().transform(transform);
       }
     };

--- a/src/backend/deformation_interpolator.cpp
+++ b/src/backend/deformation_interpolator.cpp
@@ -88,14 +88,14 @@ NodeCache::Entry* NodeCache::add(NodeId node_id, const NodeAttributes& attrs) {
     return &nodes
                 .emplace(node_id,
                          Entry{node_id,
-                               attrs.last_update_time_ns,
+                               timestamp_ns,
                                attrs.position.cast<float>()})
                 .first->second;
   }
 
   if (attrs.is_active) {
     iter->second.init_pos = attrs.position.cast<float>();
-    iter->second.timestamp = attrs.last_update_time_ns;
+    iter->second.timestamp = timestamp_ns;
   }
 
   return &iter->second;
@@ -195,7 +195,10 @@ void DeformationInterpolator::interpolate(const DynamicSceneGraph& unmerged,
 
       auto node_ptr = dsg.findNode(entry->id);
       if (node_ptr) {
-        node_ptr->attributes().position = new_pos;
+        // move the full pose (position + bounding box + orientation), not just
+        // position; dsg holds the frontend-original this cycle so this matches
+        // new_pos for the position component
+        node_ptr->attributes().transform(transform);
       }
     };
 

--- a/src/backend/deformation_interpolator.cpp
+++ b/src/backend/deformation_interpolator.cpp
@@ -59,7 +59,9 @@ std::string printTransform(const Eigen::Isometry3d& tf) {
 
 }  // namespace
 
+using spark_dsg::BoundingBox;
 using spark_dsg::NodeSymbol;
+using spark_dsg::SemanticNodeAttributes;
 
 void declare_config(DeformationInterpolator::Config& config) {
   using namespace config;
@@ -83,17 +85,26 @@ NodeCache::Entry* NodeCache::add(NodeId node_id, const NodeAttributes& attrs) {
     timestamp_ns = derived->last_observed_ns.back();
   }
 
+  // Cache the original bounding box (if any) so the deform callback can transform a
+  // fresh copy each spin instead of mutating the live box in place.
+  BoundingBox bbox;  // default INVALID
+  if (const auto semantic = dynamic_cast<const SemanticNodeAttributes*>(&attrs)) {
+    bbox = semantic->bounding_box;
+  }
+
   auto iter = nodes.find(node_id);
   if (iter == nodes.end()) {
     return &nodes
-                .emplace(node_id,
-                         Entry{node_id, timestamp_ns, attrs.position.cast<float>()})
+                .emplace(
+                    node_id,
+                    Entry{node_id, timestamp_ns, attrs.position.cast<float>(), bbox})
                 .first->second;
   }
 
   if (attrs.is_active) {
     iter->second.init_pos = attrs.position.cast<float>();
     iter->second.timestamp = timestamp_ns;
+    iter->second.init_bbox = bbox;
   }
 
   return &iter->second;
@@ -188,18 +199,23 @@ void DeformationInterpolator::interpolate(const DynamicSceneGraph& unmerged,
               << " -> transform: " << printTransform(transform);
 
       const auto new_pos = transform * entry->init_pos.cast<double>();
-      auto& attrs = unmerged.getNode(entry->id).attributes();
-      attrs.position = new_pos;
+      unmerged.getNode(entry->id).attributes().position = new_pos;
 
       auto node_ptr = dsg.findNode(entry->id);
-      if (node_ptr) {
-        // Reset to the cached original position before applying the transform so
-        // repeated deformation of an archived node stays idempotent (otherwise the
-        // transform compounds across loop-closure spins). transform() also moves
-        // the bounding box + orientation.
-        auto& dst = node_ptr->attributes();
-        dst.position = entry->init_pos.cast<double>();
-        dst.transform(transform);
+      if (!node_ptr) {
+        return;
+      }
+
+      auto& dst = node_ptr->attributes();
+      dst.position = new_pos;
+
+      // Transform a fresh copy of the cached original box (never the live box) so
+      // repeated deformation of a node -- active or archived -- never compounds.
+      if (entry->init_bbox.type != BoundingBox::Type::INVALID) {
+        if (auto semantic = dynamic_cast<SemanticNodeAttributes*>(&dst)) {
+          semantic->bounding_box = entry->init_bbox;
+          semantic->bounding_box.transform(transform);
+        }
       }
     };
 

--- a/src/backend/deformation_interpolator.cpp
+++ b/src/backend/deformation_interpolator.cpp
@@ -72,6 +72,21 @@ void declare_config(DeformationInterpolator::Config& config) {
   check(config.control_point_tolerance_s, GE, 0.0, "control_point_tolerance_s");
 }
 
+void NodeCache::Entry::update(NodeAttributes& attrs,
+                              const Eigen::Isometry3d& transform) const {
+  const auto new_pos = transform * init_pos.cast<double>();
+  attrs.position = new_pos;
+  if (init_bbox.type == BoundingBox::Type::INVALID) {
+    return;
+  }
+
+  auto derived = dynamic_cast<SemanticNodeAttributes*>(&attrs);
+  if (derived) {
+    derived->bounding_box = init_bbox;
+    derived->bounding_box.transform(transform);
+  }
+}
+
 NodeCache::Entry* NodeCache::add(NodeId node_id, const NodeAttributes& attrs) {
   uint64_t timestamp_ns = attrs.last_update_time_ns;
   if (timestamp_ns == 0u) {
@@ -85,11 +100,10 @@ NodeCache::Entry* NodeCache::add(NodeId node_id, const NodeAttributes& attrs) {
     timestamp_ns = derived->last_observed_ns.back();
   }
 
-  // Cache the original bounding box (if any) so the deform callback can transform a
-  // fresh copy each spin instead of mutating the live box in place.
-  BoundingBox bbox;  // default INVALID
-  if (const auto semantic = dynamic_cast<const SemanticNodeAttributes*>(&attrs)) {
-    bbox = semantic->bounding_box;
+  BoundingBox bbox;
+  const auto derived = dynamic_cast<const SemanticNodeAttributes*>(&attrs);
+  if (derived) {
+    bbox = derived->bounding_box;  // Cache the original bounding box of the node
   }
 
   auto iter = nodes.find(node_id);
@@ -114,7 +128,7 @@ struct EntryList {
   std::vector<NodeCache::Entry*> entries;
 
   void sort() {
-    std::sort(entries.begin(), entries.end(), [this](const auto& lhs, const auto& rhs) {
+    std::sort(entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs) {
       return lhs->timestamp < rhs->timestamp;
     });
   }
@@ -198,25 +212,13 @@ void DeformationInterpolator::interpolate(const DynamicSceneGraph& unmerged,
       VLOG(5) << "node " << spark_dsg::NodeSymbol(entry->id).str()
               << " -> transform: " << printTransform(transform);
 
-      const auto new_pos = transform * entry->init_pos.cast<double>();
-      unmerged.getNode(entry->id).attributes().position = new_pos;
-
+      entry->update(unmerged.getNode(entry->id).attributes(), transform);
       auto node_ptr = dsg.findNode(entry->id);
       if (!node_ptr) {
         return;
       }
 
-      auto& dst = node_ptr->attributes();
-      dst.position = new_pos;
-
-      // Transform a fresh copy of the cached original box (never the live box) so
-      // repeated deformation of a node -- active or archived -- never compounds.
-      if (entry->init_bbox.type != BoundingBox::Type::INVALID) {
-        if (auto semantic = dynamic_cast<SemanticNodeAttributes*>(&dst)) {
-          semantic->bounding_box = entry->init_bbox;
-          semantic->bounding_box.transform(transform);
-        }
-      }
+      entry->update(node_ptr->attributes(), transform);
     };
 
     dgraph.customDeformation(deform_func,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   test_${PROJECT_NAME}
   main.cpp
   src/resources.cpp
+  backend/test_deformation_interpolator.cpp
   backend/test_external_loop_closure.cpp
   backend/test_generic_update_functor.cpp
   backend/test_update_agents_functor.cpp

--- a/tests/backend/test_deformation_interpolator.cpp
+++ b/tests/backend/test_deformation_interpolator.cpp
@@ -5,7 +5,10 @@
 
 namespace hydra {
 
+using spark_dsg::BoundingBox;
 using spark_dsg::KhronosObjectAttributes;
+using spark_dsg::NodeAttributes;
+using spark_dsg::SemanticNodeAttributes;
 
 // Khronos objects never populate last_update_time_ns (it stays 0), so NodeCache
 // must fall back to last_observed_ns. Otherwise the cached entry is stamped 0
@@ -29,6 +32,62 @@ TEST(NodeCache, KhronosFallbackTimestampOnInsert) {
   entry = cache.add(node_id, attrs);
   ASSERT_NE(entry, nullptr);
   EXPECT_EQ(entry->timestamp, observed_ns);
+}
+
+// The deform callback transforms a copy of the cached original box rather than
+// mutating the live box in place, so NodeCache must capture the box for any node
+// that carries one (i.e. dynamic-casts to SemanticNodeAttributes).
+TEST(NodeCache, CachesBoundingBoxForSemanticNodes) {
+  SemanticNodeAttributes attrs;
+  attrs.last_update_time_ns = 10u;
+  attrs.is_active = true;
+  attrs.bounding_box =
+      BoundingBox(Eigen::Vector3f(1.0f, 2.0f, 3.0f), Eigen::Vector3f(4.0f, 5.0f, 6.0f));
+
+  NodeCache cache;
+  const NodeId node_id = 7;
+
+  auto* entry = cache.add(node_id, attrs);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_EQ(entry->init_bbox.type, BoundingBox::Type::AABB);
+  EXPECT_TRUE(entry->init_bbox.dimensions.isApprox(attrs.bounding_box.dimensions));
+  EXPECT_TRUE(
+      entry->init_bbox.world_P_center.isApprox(attrs.bounding_box.world_P_center));
+}
+
+// Re-adding an active node must refresh the cached box to the current frontend
+// original (mergeGraph re-clones the undeformed box onto active nodes each cycle).
+TEST(NodeCache, RefreshesCachedBoundingBoxWhileActive) {
+  SemanticNodeAttributes attrs;
+  attrs.last_update_time_ns = 10u;
+  attrs.is_active = true;
+  attrs.bounding_box =
+      BoundingBox(Eigen::Vector3f(1.0f, 1.0f, 1.0f), Eigen::Vector3f(0.0f, 0.0f, 0.0f));
+
+  NodeCache cache;
+  const NodeId node_id = 8;
+  cache.add(node_id, attrs);
+
+  attrs.bounding_box =
+      BoundingBox(Eigen::Vector3f(2.0f, 2.0f, 2.0f), Eigen::Vector3f(3.0f, 3.0f, 3.0f));
+  auto* entry = cache.add(node_id, attrs);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_TRUE(entry->init_bbox.dimensions.isApprox(attrs.bounding_box.dimensions));
+  EXPECT_TRUE(
+      entry->init_bbox.world_P_center.isApprox(attrs.bounding_box.world_P_center));
+}
+
+// Nodes without a bounding box (plain NodeAttributes, e.g. traversability places)
+// leave the cached box INVALID, so the deform callback skips the box entirely.
+TEST(NodeCache, LeavesBoundingBoxInvalidForNonSemanticNodes) {
+  NodeAttributes attrs;
+  attrs.last_update_time_ns = 10u;
+  attrs.is_active = true;
+
+  NodeCache cache;
+  auto* entry = cache.add(9, attrs);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_EQ(entry->init_bbox.type, BoundingBox::Type::INVALID);
 }
 
 }  // namespace hydra

--- a/tests/backend/test_deformation_interpolator.cpp
+++ b/tests/backend/test_deformation_interpolator.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include <spark_dsg/node_attributes.h>
+
+#include "hydra/backend/deformation_interpolator.h"
+
+namespace hydra {
+
+using spark_dsg::KhronosObjectAttributes;
+
+// Khronos objects never populate last_update_time_ns (it stays 0), so NodeCache
+// must fall back to last_observed_ns. Otherwise the cached entry is stamped 0
+// and the deformation solver matches it against the earliest control points
+// instead of the ones near the object's observation time.
+TEST(NodeCache, KhronosFallbackTimestampOnInsert) {
+  constexpr uint64_t observed_ns = 1782847154557208075ULL;
+  KhronosObjectAttributes attrs;
+  attrs.last_update_time_ns = 0;
+  attrs.last_observed_ns = {observed_ns};
+  attrs.is_active = true;
+
+  NodeCache cache;
+  const NodeId node_id = 42;
+
+  auto* entry = cache.add(node_id, attrs);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_EQ(entry->timestamp, observed_ns);
+
+  // re-adding an active node must keep the fallback stamp, not reset it to 0
+  entry = cache.add(node_id, attrs);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_EQ(entry->timestamp, observed_ns);
+}
+
+}  // namespace hydra

--- a/tests/backend/test_deformation_interpolator.cpp
+++ b/tests/backend/test_deformation_interpolator.cpp
@@ -7,87 +7,50 @@ namespace hydra {
 
 using spark_dsg::BoundingBox;
 using spark_dsg::KhronosObjectAttributes;
-using spark_dsg::NodeAttributes;
 using spark_dsg::SemanticNodeAttributes;
 
-// Khronos objects never populate last_update_time_ns (it stays 0), so NodeCache
-// must fall back to last_observed_ns. Otherwise the cached entry is stamped 0
-// and the deformation solver matches it against the earliest control points
-// instead of the ones near the object's observation time.
-TEST(NodeCache, KhronosFallbackTimestampOnInsert) {
-  constexpr uint64_t observed_ns = 1782847154557208075ULL;
+TEST(DeformationInterpolator, KhronosFallbackTimestampOnInsert) {
   KhronosObjectAttributes attrs;
   attrs.last_update_time_ns = 0;
-  attrs.last_observed_ns = {observed_ns};
+  attrs.last_observed_ns = {100};
   attrs.is_active = true;
 
   NodeCache cache;
-  const NodeId node_id = 42;
-
-  auto* entry = cache.add(node_id, attrs);
+  auto entry = cache.add(0, attrs);
   ASSERT_NE(entry, nullptr);
-  EXPECT_EQ(entry->timestamp, observed_ns);
+  EXPECT_EQ(entry->timestamp, 100u);
 
-  // re-adding an active node must keep the fallback stamp, not reset it to 0
-  entry = cache.add(node_id, attrs);
+  entry = cache.add(0, attrs);
   ASSERT_NE(entry, nullptr);
-  EXPECT_EQ(entry->timestamp, observed_ns);
+  EXPECT_EQ(entry->timestamp, 100u);
 }
 
-// The deform callback transforms a copy of the cached original box rather than
-// mutating the live box in place, so NodeCache must capture the box for any node
-// that carries one (i.e. dynamic-casts to SemanticNodeAttributes).
-TEST(NodeCache, CachesBoundingBoxForSemanticNodes) {
+TEST(DeformationInterpolator, BoundingBoxCorrect) {
+  const BoundingBox bbox1(Eigen::Vector3f(1.0f, 1.0f, 1.0f),
+                          Eigen::Vector3f(0.0f, 0.0f, 0.0f));
+  const BoundingBox bbox2(Eigen::Vector3f(2.0f, 2.0f, 2.0f),
+                          Eigen::Vector3f(3.0f, 3.0f, 3.0f));
+
   SemanticNodeAttributes attrs;
   attrs.last_update_time_ns = 10u;
   attrs.is_active = true;
-  attrs.bounding_box =
-      BoundingBox(Eigen::Vector3f(1.0f, 2.0f, 3.0f), Eigen::Vector3f(4.0f, 5.0f, 6.0f));
+  attrs.bounding_box = bbox1;
 
   NodeCache cache;
-  const NodeId node_id = 7;
-
-  auto* entry = cache.add(node_id, attrs);
+  auto entry = cache.add(0, attrs);
   ASSERT_NE(entry, nullptr);
-  EXPECT_EQ(entry->init_bbox.type, BoundingBox::Type::AABB);
-  EXPECT_TRUE(entry->init_bbox.dimensions.isApprox(attrs.bounding_box.dimensions));
-  EXPECT_TRUE(
-      entry->init_bbox.world_P_center.isApprox(attrs.bounding_box.world_P_center));
-}
+  EXPECT_EQ(entry->init_bbox, bbox1);
 
-// Re-adding an active node must refresh the cached box to the current frontend
-// original (mergeGraph re-clones the undeformed box onto active nodes each cycle).
-TEST(NodeCache, RefreshesCachedBoundingBoxWhileActive) {
-  SemanticNodeAttributes attrs;
-  attrs.last_update_time_ns = 10u;
-  attrs.is_active = true;
-  attrs.bounding_box =
-      BoundingBox(Eigen::Vector3f(1.0f, 1.0f, 1.0f), Eigen::Vector3f(0.0f, 0.0f, 0.0f));
-
-  NodeCache cache;
-  const NodeId node_id = 8;
-  cache.add(node_id, attrs);
-
-  attrs.bounding_box =
-      BoundingBox(Eigen::Vector3f(2.0f, 2.0f, 2.0f), Eigen::Vector3f(3.0f, 3.0f, 3.0f));
-  auto* entry = cache.add(node_id, attrs);
+  attrs.bounding_box = bbox2;
+  entry = cache.add(0, attrs);
   ASSERT_NE(entry, nullptr);
-  EXPECT_TRUE(entry->init_bbox.dimensions.isApprox(attrs.bounding_box.dimensions));
-  EXPECT_TRUE(
-      entry->init_bbox.world_P_center.isApprox(attrs.bounding_box.world_P_center));
-}
+  EXPECT_EQ(entry->init_bbox, bbox2);
 
-// Nodes without a bounding box (plain NodeAttributes, e.g. traversability places)
-// leave the cached box INVALID, so the deform callback skips the box entirely.
-TEST(NodeCache, LeavesBoundingBoxInvalidForNonSemanticNodes) {
-  NodeAttributes attrs;
-  attrs.last_update_time_ns = 10u;
-  attrs.is_active = true;
-
-  NodeCache cache;
-  auto* entry = cache.add(9, attrs);
+  attrs.is_active = false;
+  attrs.bounding_box = bbox1;
+  entry = cache.add(0, attrs);
   ASSERT_NE(entry, nullptr);
-  EXPECT_EQ(entry->init_bbox.type, BoundingBox::Type::INVALID);
+  EXPECT_EQ(entry->init_bbox, bbox2);
 }
 
 }  // namespace hydra


### PR DESCRIPTION
Found while working on the image-keyframing code. Two related bugs in `DeformationInterpolator` (added in #115) that leave Khronos objects mis-placed after loop-closure optimization — object positions and their 3D bounding boxes end up floating off the deformed mesh.

### 1. `NodeCache::add` discards the resolved timestamp
`NodeCache::add` computes a fallback timestamp from `last_observed_ns` when `last_update_time_ns == 0` — which is always the case for Khronos objects — but then stores `attrs.last_update_time_ns` (0) in the cache `Entry` instead of the computed `timestamp_ns` (both the emplace path and the active-refresh path).

Every object is therefore stamped `0`, so `customDeformation` matches it against the earliest control points (trajectory start) instead of the control points near its observation time. The placement error grows with how late the object was observed — on an infinite-corridor bag, error-vs-observation-time correlated at Pearson **r = +0.79** (late objects ~28 m off, well beyond a 10 m camera range).

Fix: stamp the entry with the resolved `timestamp_ns`.

### 2. `interpolate()` only moved the position, not the bounding box
The deform callback set `node.position` but never touched the object bounding box, so once the positions were corrected the 3D boxes still floated at the un-deformed frontend pose (`bbox_center` up to ~20 m from the corrected position).

Fix: cache each node's original bounding box in the `NodeCache` entry (for nodes that `dynamic_cast` to `SemanticNodeAttributes`), and on each deform spin write a **fresh copy** of the cached box into the node and transform that copy; position is likewise recomputed from the cached `init_pos`. Because nothing is transformed in place, deformation is idempotent for **active and archived** nodes alike — an archived node revisited on a later loop-closure spin no longer double-applies the transform. (The earlier in-place `transform()` compounded on archived nodes, driving the traversability places that share this interpolator to drift to z ~40 m.) Only position + bounding box are touched, which keeps the deformation easy to reason about.

### Notes / follow-ups
- Scoped to position + bounding box via the `SemanticNodeAttributes` cast. `ObjectNodeAttributes::world_R_object` (only meaningful when `registered`) and Khronos world-frame `trajectory_positions` / `dynamic_object_points` (empty for static objects) are not transformed; a `KhronosObjectAttributes::transform` override is the natural follow-up. The object-local `mesh` is stored relative to the bbox origin, so it rides the bbox automatically.

### Testing
- Fix 1: object positions snap onto the mesh (r +0.79 → +0.07; 0/144 objects >2 m off).
- Fix 2, validated end-to-end on the infinite-corridor bag: `bbox_center → mesh` median **0.065 m**, 0/144 >2 m (previously 3.58 m median / 99 of 144 off); archived traversability places z median **0.97 m** / max 3.66 m (previously 17.4 m / 39.8 m). The existing `GenericUpdateFunctor.shouldUpdate` idempotency test stays green.
- Added `NodeCache` regression tests: the timestamp fallback, and the bounding-box caching (cached on insert + refreshed while active; stays INVALID for non-semantic nodes).
