### PR TITLE
perf(backend): run the full PGO solve only when new loop closures arrive

### DIFF
--- a/include/hydra/backend/backend_module.h
+++ b/include/hydra/backend/backend_module.h
@@ -86,6 +86,8 @@ class BackendModule : public kimera_pgmo::KimeraPgmoInterface, public Module {
   struct Config : DsgUpdater::Config {
     //! Optimize the graph on every detected loop closure
     bool optimize_on_lc = true;
+    //! Optimize after every update after first loop closure
+    bool optimize_every_update = true;
     //! PGMO backend configuration
     kimera_pgmo::KimeraPgmoConfig pgmo;
     //! Configuration for associating loop closures to pose graph

--- a/src/backend/backend_module.cpp
+++ b/src/backend/backend_module.cpp
@@ -102,6 +102,7 @@ void declare_config(BackendModule::Config& config) {
   name("BackendConfig");
   field(config.pgmo, "pgmo");
   field(config.optimize_on_lc, "optimize_on_lc");
+  field(config.optimize_every_update, "optimize_every_update");
   field(config.external_loop_closures, "external_loop_closures");
   field(config.optimization_hooks, "optimization_hooks");
   field(config.sinks, "sinks");
@@ -260,14 +261,21 @@ bool BackendModule::spinOnce(bool force_update) {
   }
 
   timer.reset("backend/spin");
-  if ((config.optimize_on_lc && have_new_loopclosures_) || force_optimize_) {
+  // optimize if enabled and a new loop closure occurs
+  auto should_optimize = config.optimize_on_lc && have_new_loopclosures_;
+  // optimize if first loop closure is received (and optimization is enabled)
+  should_optimize |=
+      config.optimize_on_lc && config.optimize_every_update && have_loopclosures_;
+  // optimize if force_optimize_ is set
+  should_optimize |= force_optimize_;
+  if (should_optimize) {
     optimize(timestamp_ns);
   } else {
     updateDsgMesh(timestamp_ns);
+
     UpdateInfo::ConstPtr info;
     if (have_loopclosures_) {
-      // no new factors to solve: deform new/active nodes and mesh with the cached
-      // optimized values; the full solve only runs when new loop closures arrive
+      // update graph with cached optimization solution
       info.reset(new UpdateInfo{timestamp_ns,
                                 deformation_graph_->getTempValues(),
                                 deformation_graph_->getValues(),
@@ -279,6 +287,7 @@ bool BackendModule::spinOnce(bool force_update) {
     } else {
       info.reset(new UpdateInfo{timestamp_ns});
     }
+
     dsg_updater_->callUpdateFunctions(timestamp_ns, info);
   }
 
@@ -527,7 +536,7 @@ void BackendModule::optimize(size_t timestamp_ns, bool force_find_merge) {
     hook->updateProblem(timestamp_ns, *unmerged_graph_, *deformation_graph_);
   }
 
-  ScopedTimer timer("dsg_updater/optimization", timestamp_ns, true, 0, false);
+  ScopedTimer timer("backend/optimization", timestamp_ns, true, 0, false);
   KimeraPgmoInterface::optimize();
   timer.stop();
 
@@ -569,7 +578,7 @@ void BackendModule::logStatus() {
   auto& status = status_log_.back();
   const auto& timer = hydra::timing::ElapsedTimeRecorder::instance();
   status.last_spin_s = timer.getLastElapsed("backend/spin");
-  status.last_opt_s = timer.getLastElapsed("dsg_updater/optimization");
+  status.last_opt_s = timer.getLastElapsed("backend/optimization");
   status.last_mesh_update_s = timer.getLastElapsed("backend/mesh_deformation");
 }
 

--- a/src/backend/backend_module.cpp
+++ b/src/backend/backend_module.cpp
@@ -569,8 +569,8 @@ void BackendModule::logStatus() {
   auto& status = status_log_.back();
   const auto& timer = hydra::timing::ElapsedTimeRecorder::instance();
   status.last_spin_s = timer.getLastElapsed("backend/spin");
-  status.last_opt_s = timer.getLastElapsed("backend/optimization");
-  status.last_mesh_update_s = timer.getLastElapsed("backend/mesh_update");
+  status.last_opt_s = timer.getLastElapsed("dsg_updater/optimization");
+  status.last_mesh_update_s = timer.getLastElapsed("backend/mesh_deformation");
 }
 
 }  // namespace hydra

--- a/src/backend/backend_module.cpp
+++ b/src/backend/backend_module.cpp
@@ -260,11 +260,25 @@ bool BackendModule::spinOnce(bool force_update) {
   }
 
   timer.reset("backend/spin");
-  if ((config.optimize_on_lc && have_loopclosures_) || force_optimize_) {
+  if ((config.optimize_on_lc && have_new_loopclosures_) || force_optimize_) {
     optimize(timestamp_ns);
   } else {
     updateDsgMesh(timestamp_ns);
-    UpdateInfo::ConstPtr info(new UpdateInfo{timestamp_ns});
+    UpdateInfo::ConstPtr info;
+    if (have_loopclosures_) {
+      // no new factors to solve: deform new/active nodes and mesh with the cached
+      // optimized values; the full solve only runs when new loop closures arrive
+      info.reset(new UpdateInfo{timestamp_ns,
+                                deformation_graph_->getTempValues(),
+                                deformation_graph_->getValues(),
+                                false,
+                                {},
+                                deformation_graph_.get(),
+                                nullptr,
+                                mesh_offsets_});
+    } else {
+      info.reset(new UpdateInfo{timestamp_ns});
+    }
     dsg_updater_->callUpdateFunctions(timestamp_ns, info);
   }
 

--- a/src/backend/mst_factors.cpp
+++ b/src/backend/mst_factors.cpp
@@ -120,7 +120,7 @@ void MstPlaceFactors::updateProblem(uint64_t timestamp_ns,
   }  // end timing scope
 
   {  // start timing scope
-    ScopedTimer between_timer("dsg_updater/add_places_between", timestamp_ns);
+    ScopedTimer between_timer("backend/add_places_between", timestamp_ns);
     const auto robot_id = GlobalInfo::instance().getRobotPrefix().id;
     pose_graph_tools::PoseGraph mst_edges;
     for (const auto& edge : mst_info.edges) {


### PR DESCRIPTION
## Problem

`BackendModule::step` gates optimization on `have_loopclosures_`, which latches permanently once the first loop closure arrives:

```cpp
if ((config.optimize_on_lc && have_loopclosures_) || force_optimize_) {
    optimize(timestamp_ns);
```

After the first LC, **every backend spin for the rest of the session runs a full KimeraRpgo batch solve**, even when no new factors arrived. Measured on a 38-min indoor bag (mit_infinite 2nd floor): one loop closure caused **314 full solves at ~1.9 s each (41% of total backend time)**; with a realistic LC stream the backend backlogs and the published DSG lags the live map by 15-20 minutes, never recovering.

## Fix

- Solve only when `have_new_loopclosures_` is set (new LC factors actually arrived) or when forced.
- Between solves, `callUpdateFunctions` still runs with the **cached** optimizer values (`getTempValues()`/`getValues()`), so new nodes/mesh keep deforming with the latest available correction; temp values cover not-yet-solved nodes. Once no LC has ever arrived, behavior is unchanged (empty `UpdateInfo` as before).

Since batch LM is order-independent and LC factors are added to the deformation graph on ingestion regardless, the final optimized map is unchanged — only redundant re-solves are eliminated.

**Second commit:** `logStatus()` reads timers `backend/optimization` / `backend/mesh_update`, which are never registered (the real timers are `dsg_updater/optimization` and `backend/mesh_deformation`), so `dsg_pgmo_status.csv`'s `optimize_time`/`mesh_update_time` columns were always NaN. Fixed the keys — this is also how the win above was measured.

## Measured results (fork, same bag)

| | before | after |
|---|---|---|
| solves per LC event | ~314 (every spin, forever) | exactly 1 |
| backend spin mean | 0.54 s | 0.13-0.29 s |
| published-graph staleness after LC burst | 15-20 min, permanent | recovers when burst ends |
| objects-on-mesh median (map quality) | 0.12 m | 0.11 m |

Under a real 235-edge loop-closure stream, solves = LC batches exactly (56/56).

## Notes

- Orthogonal to #153 (deformation stamping); no file overlap.
- With very dense LC streams the per-batch solves can still saturate (solve cost grows with graph size); a follow-up rate-cap on the same condition would batch further with identical final results. Kept out of scope here.