### PR TITLE
Feature/color alpha

### DIFF
--- a/include/hydra/input/camera.h
+++ b/include/hydra/input/camera.h
@@ -97,6 +97,8 @@ class Camera : public Sensor {
   bool pointIsInViewFrustum(const Eigen::Vector3f& point_C,
                             float inflation_distance = 0.0f) const override;
 
+  Eigen::Vector3f unprojectPixel(float u, float v, float z) const;
+
   cv::Mat computeVertexMap(const cv::Mat& depth_image,
                            const Eigen::Isometry3f* T_W_C = nullptr) const;
 

--- a/include/hydra/input/input_data.h
+++ b/include/hydra/input/input_data.h
@@ -16,10 +16,15 @@ struct InputData {
 
   // Types of the stored image data.
   using ColorType = cv::Vec3b;
+  inline static constexpr auto ColorMatType = CV_8UC3;
   using RangeType = float;
+  inline static constexpr auto RangeMatType = CV_32FC1;
   using VertexType = cv::Vec3f;
+  inline static constexpr auto VertexMatType = CV_32FC3;
   using LabelType = int;
+  inline static constexpr auto LabelMatType = CV_32SC1;
   using InstanceType = int16_t;
+  inline static constexpr auto InstanceMatType = CV_16SC1;
 
   explicit InputData(Sensor::ConstPtr sensor) : sensor_(std::move(sensor)) {}
   virtual ~InputData() = default;

--- a/include/hydra/input/input_data.h
+++ b/include/hydra/input/input_data.h
@@ -25,6 +25,8 @@ struct InputData {
   inline static constexpr auto LabelMatType = CV_32SC1;
   using InstanceType = int16_t;
   inline static constexpr auto InstanceMatType = CV_16SC1;
+  using MaskType = uint8_t;
+  inline static constexpr auto MaskMatType = CV_8UC1;
 
   explicit InputData(Sensor::ConstPtr sensor) : sensor_(std::move(sensor)) {}
   virtual ~InputData() = default;
@@ -35,6 +37,8 @@ struct InputData {
   Eigen::Isometry3d world_T_body;
   //! Color image as RGB.
   cv::Mat color_image;
+  //! Color mask (primarily for backprojected LiDAR)
+  cv::Mat color_mask;
   //! Depth image as planar depth in meters.
   cv::Mat depth_image;
   //! Ray lengths in meters.

--- a/include/hydra/input/sensor_input_packet.h
+++ b/include/hydra/input/sensor_input_packet.h
@@ -89,6 +89,8 @@ struct CloudInputPacket : public SensorInputPacket {
   cv::Mat points;
   //! Colors for each point
   cv::Mat colors;
+  //! Color mask for each point
+  cv::Mat color_mask;
   //! Labels for each point
   cv::Mat labels;
   //! Instance IDs for each point

--- a/include/hydra/reconstruction/projection_interpolators.h
+++ b/include/hydra/reconstruction/projection_interpolators.h
@@ -49,9 +49,7 @@
 
 #include <spark_dsg/color.h>
 
-#include <memory>
 #include <opencv2/core/mat.hpp>
-#include <string>
 
 namespace hydra {
 
@@ -111,6 +109,14 @@ class ProjectionInterpolator {
    */
   virtual int interpolateID(const cv::Mat& id_image,
                             const InterpolationWeights& weights) const = 0;
+
+  /**
+   * @brief Compute a binary mask value based on the provided weights.
+   * @param mask_image ID image as 8UC1 to interpolate in.
+   * @return bool The interpolated binary mask value.
+   */
+  virtual bool interpolateMask(const cv::Mat& mask_image,
+                               const InterpolationWeights& weights) const = 0;
 };
 
 /**
@@ -134,6 +140,9 @@ class InterpolatorNearest : public ProjectionInterpolator {
 
   int interpolateID(const cv::Mat& id_image,
                     const InterpolationWeights& weights) const override;
+
+  bool interpolateMask(const cv::Mat& mask_image,
+                       const InterpolationWeights& weights) const override;
 };
 
 void declare_config(InterpolatorNearest::Config& config);
@@ -159,6 +168,9 @@ class InterpolatorBilinear : public ProjectionInterpolator {
 
   int interpolateID(const cv::Mat& id_image,
                     const InterpolationWeights& weights) const override;
+
+  bool interpolateMask(const cv::Mat& mask_image,
+                       const InterpolationWeights& weights) const override;
 };
 
 void declare_config(InterpolatorBilinear::Config& config);
@@ -189,6 +201,9 @@ class InterpolatorAdaptive : public InterpolatorBilinear {
 
   int interpolateID(const cv::Mat& id_image,
                     const InterpolationWeights& weights) const override;
+
+  bool interpolateMask(const cv::Mat& mask_image,
+                       const InterpolationWeights& weights) const override;
 
  private:
   const int u_offset_[4] = {0, 0, 1, 1};

--- a/src/common/labelspace.cpp
+++ b/src/common/labelspace.cpp
@@ -42,6 +42,8 @@
 #include <opencv2/core/mat.hpp>
 #include <string>
 
+#include "hydra/input/input_data.h"
+
 namespace {
 
 struct LabelRemapRow {
@@ -159,8 +161,8 @@ void LabelRemapper::remapImage(cv::Mat& img) const {
 
   for (int r = 0; r < img.rows; ++r) {
     for (int c = 0; c < img.cols; ++c) {
-      const auto pixel = img.at<int32_t>(r, c);
-      img.at<int32_t>(r, c) = remapLabel(pixel).value_or(-1);
+      const auto pixel = img.at<InputData::LabelType>(r, c);
+      img.at<InputData::LabelType>(r, c) = remapLabel(pixel).value_or(-1);
     }
   }
 }

--- a/src/common/semantic_color_map.cpp
+++ b/src/common/semantic_color_map.cpp
@@ -37,6 +37,7 @@
 #include <glog/logging.h>
 #include <glog/stl_logging.h>
 
+#include "hydra/input/input_data.h"
 #include "hydra/utils/csv_reader.h"
 
 namespace hydra {
@@ -156,12 +157,13 @@ cv::Mat SemanticColorMap::colorsToLabels(const cv::Mat& colors,
 
   CHECK_EQ(colors.type(), CV_8UC3);
 
-  cv::Mat label_image(colors.size(), CV_32SC1);
+  cv::Mat label_image(colors.size(), InputData::LabelMatType);
   for (int r = 0; r < colors.rows; ++r) {
     for (int c = 0; c < colors.cols; ++c) {
       const auto& pixel = colors.at<cv::Vec3b>(r, c);
       const spark_dsg::Color color(pixel[0], pixel[1], pixel[2]);
-      label_image.at<int32_t>(r, c) = getLabelFromColor(color).value_or(default_label);
+      label_image.at<InputData::LabelType>(r, c) =
+          getLabelFromColor(color).value_or(default_label);
     }
   }
 

--- a/src/input/camera.cpp
+++ b/src/input/camera.cpp
@@ -195,7 +195,7 @@ bool Camera::pointIsInViewFrustum(const Eigen::Vector3f& point_C,
 cv::Mat Camera::computeVertexMap(const cv::Mat& depth_image,
                                  const Eigen::Isometry3f* T_W_C) const {
   // Compute the 3D pointcloud from a depth image.
-  cv::Mat vertices(depth_image.size(), CV_32FC3);
+  cv::Mat vertices(depth_image.size(), InputData::VertexMatType);
   const float fx_inv = 1.f / config_.fx;
   const float fy_inv = 1.f / config_.fy;
   for (int v = 0; v < depth_image.rows; v++) {
@@ -208,7 +208,7 @@ cv::Mat Camera::computeVertexMap(const cv::Mat& depth_image,
       VLOG(15) << "(" << u << ", " << v << "), d=" << depth << ", fx=" << fx_inv
                << ", fy=" << fy_inv << ", cx=" << config_.cx << ", cy=" << config_.cy
                << " -> " << p_W.transpose();
-      auto& vertex = vertices.at<cv::Vec3f>(v, u);
+      auto& vertex = vertices.at<InputData::VertexType>(v, u);
       vertex[0] = p_W.x();
       vertex[1] = p_W.y();
       vertex[2] = p_W.z();
@@ -222,7 +222,7 @@ cv::Mat Camera::computeRangeImage(const cv::Mat& depth_image,
                                   float* min_range,
                                   float* max_range) const {
   // Compute the range (=radial distance) from the pointcloud.
-  cv::Mat range_image(depth_image.size(), CV_32FC1);
+  cv::Mat range_image(depth_image.size(), InputData::RangeMatType);
   const float fx_inv = 1.0f / config_.fx;
   const float fy_inv = 1.0f / config_.fy;
   if (min_range) {
@@ -240,7 +240,7 @@ cv::Mat Camera::computeRangeImage(const cv::Mat& depth_image,
                                 depth * (static_cast<float>(v) - config_.cy) * fy_inv,
                                 depth);
       const float range = p_C.norm();
-      range_image.at<float>(v, u) = range;
+      range_image.at<InputData::RangeType>(v, u) = range;
       if (min_range) {
         *min_range = std::min(*min_range, range);
       }
@@ -258,7 +258,7 @@ cv::Mat Camera::computeRangeImageFromPoints(const cv::Mat& points,
                                             float* min_range,
                                             float* max_range) {
   // Compute the range (=radial distance) from the pointcloud.
-  cv::Mat range_image(points.size(), CV_32FC1);
+  cv::Mat range_image(points.size(), InputData::RangeMatType);
   if (min_range) {
     *min_range = std::numeric_limits<float>::max();
   }
@@ -269,12 +269,12 @@ cv::Mat Camera::computeRangeImageFromPoints(const cv::Mat& points,
 
   for (int v = 0; v < points.rows; v++) {
     for (int u = 0; u < points.cols; u++) {
-      const auto& point = points.at<cv::Vec3f>(v, u);
+      const auto& point = points.at<InputData::VertexType>(v, u);
       const float x = point[0];
       const float y = point[1];
       const float z = point[2];
       const auto range = std::sqrt(x * x + y * y + z * z);
-      range_image.at<float>(v, u) = range;
+      range_image.at<InputData::RangeType>(v, u) = range;
       if (min_range) {
         *min_range = std::min(*min_range, range);
       }

--- a/src/input/camera.cpp
+++ b/src/input/camera.cpp
@@ -192,6 +192,11 @@ bool Camera::pointIsInViewFrustum(const Eigen::Vector3f& point_C,
   return true;
 }
 
+Eigen::Vector3f Camera::unprojectPixel(float u, float v, float z) const {
+  return Eigen::Vector3f(
+      z * (u - config_.cx) / config_.fx, z * (v - config_.cy) / config_.fy, z);
+}
+
 cv::Mat Camera::computeVertexMap(const cv::Mat& depth_image,
                                  const Eigen::Isometry3f* T_W_C) const {
   // Compute the 3D pointcloud from a depth image.

--- a/src/input/input_conversion.cpp
+++ b/src/input/input_conversion.cpp
@@ -24,9 +24,9 @@ bool convertLabels(InputData& data) {
   }
 
   // Enforcing requirement for int32_t at this point
-  if (data.label_image.type() != CV_32SC1) {
-    cv::Mat new_label_image(data.label_image.size(), CV_32SC1);
-    data.label_image.convertTo(new_label_image, CV_32SC1);
+  if (data.label_image.type() != InputData::LabelMatType) {
+    cv::Mat new_label_image(data.label_image.size(), InputData::LabelMatType);
+    data.label_image.convertTo(new_label_image, InputData::LabelMatType);
     data.label_image = new_label_image;
   }
 
@@ -69,7 +69,7 @@ bool convertColor(InputData& data) {
     return true;
   }
 
-  if (data.color_image.type() != CV_8UC3) {
+  if (data.color_image.type() != InputData::ColorMatType) {
     LOG(ERROR) << "only 3-channel rgb images supported";
     return false;
   }
@@ -128,13 +128,14 @@ bool normalizeData(InputData& data, bool normalize_labels) {
     return false;
   }
 
-  if (!data.instance_image.empty() && data.instance_image.type() != CV_16SC1) {
-    cv::Mat instances(data.instance_image.size(), CV_16SC1);
-    data.instance_image.convertTo(instances, CV_16SC1);
+  if (!data.instance_image.empty() &&
+      data.instance_image.type() != InputData::InstanceMatType) {
+    cv::Mat instances(data.instance_image.size(), InputData::InstanceMatType);
+    data.instance_image.convertTo(instances, InputData::InstanceMatType);
     data.instance_image = instances;
   }
 
-  if (!data.vertex_map.empty() && data.vertex_map.type() != CV_32FC3) {
+  if (!data.vertex_map.empty() && data.vertex_map.type() != InputData::VertexMatType) {
     LOG(ERROR) << "pointcloud must be CV_32FC3, not " << showTypeInfo(data.vertex_map);
     return false;
   }
@@ -154,7 +155,7 @@ void convertVertexMap(InputData& data, bool in_world_frame) {
 
   for (int r = 0; r < data.vertex_map.rows; ++r) {
     for (int c = 0; c < data.vertex_map.cols; ++c) {
-      auto& point = data.vertex_map.at<cv::Vec3f>(r, c);
+      auto& point = data.vertex_map.at<InputData::VertexType>(r, c);
       Eigen::Vector3f point_eigen(point[0], point[1], point[2]);
       point_eigen = transform * point_eigen;
       point[0] = point_eigen.x();

--- a/src/input/lidar.cpp
+++ b/src/input/lidar.cpp
@@ -175,6 +175,7 @@ bool Lidar::finalizeRepresentations(InputData& input, bool force_world_frame) co
 
   const auto sensor_T_world = input.getSensorPose().cast<float>().inverse();
   const auto has_color = !input.color_image.empty();
+  const auto has_color_mask = !input.color_mask.empty();
   const auto has_labels = !input.label_image.empty();
   const auto has_instances = !input.instance_image.empty();
   const auto structured =
@@ -188,6 +189,12 @@ bool Lidar::finalizeRepresentations(InputData& input, bool force_world_frame) co
   if (has_color) {
     color = cv::Mat(height_, width_, InputData::ColorMatType);
     color = 0;
+  }
+
+  cv::Mat color_mask;
+  if (has_color_mask) {
+    color_mask = cv::Mat(height_, width_, InputData::MaskMatType);
+    color_mask = 0;
   }
 
   cv::Mat labels;
@@ -257,6 +264,11 @@ bool Lidar::finalizeRepresentations(InputData& input, bool force_world_frame) co
           input.color_image.at<InputData::ColorType>(point_idx);
     }
 
+    if (has_color_mask) {
+      color_mask.at<InputData::MaskType>(v, u) =
+          input.color_mask.at<InputData::MaskType>(point_idx);
+    }
+
     if (has_labels) {
       labels.at<InputData::LabelType>(v, u) =
           input.label_image.at<InputData::LabelType>(point_idx);
@@ -278,6 +290,7 @@ bool Lidar::finalizeRepresentations(InputData& input, bool force_world_frame) co
   input.label_image = labels;
   input.instance_image = instances;
   input.color_image = color;
+  input.color_mask = color_mask;
   if (!structured) {
     input.vertex_map = vertex_image;
   }

--- a/src/input/lidar.cpp
+++ b/src/input/lidar.cpp
@@ -182,27 +182,30 @@ bool Lidar::finalizeRepresentations(InputData& input, bool force_world_frame) co
 
   input.min_range = std::numeric_limits<float>::max();
   input.max_range = std::numeric_limits<float>::lowest();
-  input.range_image = cv::Mat(height_, width_, CV_32FC1, 0.0f);
+  input.range_image = cv::Mat(height_, width_, InputData::RangeMatType, 0.0f);
 
   cv::Mat color;
   if (has_color) {
-    color = cv::Mat(height_, width_, CV_8UC3);
+    color = cv::Mat(height_, width_, InputData::ColorMatType);
     color = 0;
   }
 
   cv::Mat labels;
   if (has_labels) {
-    labels = cv::Mat(height_, width_, CV_32SC1, -1);
+    labels = cv::Mat(height_, width_, InputData::LabelMatType);
+    labels = -1;
   }
 
   cv::Mat instances;
   if (has_instances) {
-    instances = cv::Mat::zeros(height_, width_, CV_16SC1);
+    instances = cv::Mat(height_, width_, InputData::InstanceMatType);
+    instances = 0;
   }
 
   cv::Mat vertex_image;
   if (!structured) {
-    vertex_image = cv::Mat(height_, width_, CV_32FC3, cv::Scalar(0.0, 0.0, 0.0));
+    const cv::Scalar init(0.0, 0.0, 0.0);
+    vertex_image = cv::Mat(height_, width_, InputData::VertexMatType, init);
   }
 
   size_t point_idx = 0;
@@ -237,20 +240,21 @@ bool Lidar::finalizeRepresentations(InputData& input, bool force_world_frame) co
     const auto range_m = p_C.norm();
     input.min_range = std::min(input.min_range, range_m);
     input.max_range = std::max(input.max_range, range_m);
-    if (!(input.range_image.at<float>(v, u) == 0.0f ||
-          range_m < input.range_image.at<float>(v, u))) {
+    if (!(input.range_image.at<InputData::RangeType>(v, u) == 0.0f ||
+          range_m < input.range_image.at<InputData::RangeType>(v, u))) {
       ++point_iter;
       ++point_idx;
       continue;  // Skip the pixel if it has already been updated with a closer point
     }
 
-    input.range_image.at<float>(v, u) = range_m;
+    input.range_image.at<InputData::RangeType>(v, u) = range_m;
     if (!structured) {
-      vertex_image.at<cv::Vec3f>(v, u) = *point_iter;
+      vertex_image.at<InputData::VertexType>(v, u) = *point_iter;
     }
 
     if (has_color) {
-      color.at<cv::Vec3b>(v, u) = input.color_image.at<cv::Vec3b>(point_idx);
+      color.at<InputData::ColorType>(v, u) =
+          input.color_image.at<InputData::ColorType>(point_idx);
     }
 
     if (has_labels) {

--- a/src/input/sensor_input_packet.cpp
+++ b/src/input/sensor_input_packet.cpp
@@ -117,6 +117,7 @@ bool CloudInputPacket::fillInputDataImpl(InputData& msg) const {
   msg.vertex_map = points;
   msg.points_in_world_frame = in_world_frame;
   msg.color_image = colors;
+  msg.color_mask = color_mask;
   msg.label_image = labels;
   msg.instance_image = instances;
 
@@ -136,6 +137,13 @@ bool CloudInputPacket::fillInputDataImpl(InputData& msg) const {
 
   if (!msg.color_image.empty() && !sizesMatch(msg.vertex_map, msg.color_image)) {
     LOG(ERROR) << "Color dimensions " << showImageDim(msg.color_image)
+               << " do not match pointcloud dimensions "
+               << showImageDim(msg.vertex_map);
+    return false;
+  }
+
+  if (!msg.color_mask.empty() && !sizesMatch(msg.vertex_map, msg.color_mask)) {
+    LOG(ERROR) << "Color mask dimensions " << showImageDim(msg.color_mask)
                << " do not match pointcloud dimensions "
                << showImageDim(msg.vertex_map);
     return false;

--- a/src/reconstruction/integration_masking.cpp
+++ b/src/reconstruction/integration_masking.cpp
@@ -38,6 +38,8 @@
 
 #include <opencv2/core.hpp>
 
+#include "hydra/input/input_data.h"
+
 namespace hydra {
 namespace {
 
@@ -49,7 +51,7 @@ inline std::string showImageDim(const cv::Mat& mat) {
 
 inline bool initMask(const cv::Mat& input, cv::Mat& mask) {
   if (mask.empty()) {
-    mask = cv::Mat::zeros(input.rows, input.cols, CV_32SC1);
+    mask = cv::Mat::zeros(input.rows, input.cols, CV_8UC1);
     return true;
   }
 
@@ -59,11 +61,11 @@ inline bool initMask(const cv::Mat& input, cv::Mat& mask) {
     return false;
   }
 
-  if (mask.type() != CV_32SC1) {
-    LOG(WARNING) << "Invalid mask type! Must be CV_32SC!";
+  if (mask.type() != CV_8UC1) {
+    LOG(WARNING) << "Invalid mask type! Must be CV_8UC1!";
 
     cv::Mat converted;
-    mask.convertTo(converted, CV_32SC1);
+    mask.convertTo(converted, CV_8UC1);
     mask = converted;
   }
 
@@ -79,8 +81,8 @@ bool maskInvalidSemantics(const cv::Mat& labels,
     return true;  // more efficient to not init mask if it is going to be empty
   }
 
-  if (labels.type() != CV_32SC1) {
-    LOG(ERROR) << "Invalid label image! Type must be CV_32SC1";
+  if (labels.type() != InputData::LabelMatType) {
+    LOG(ERROR) << "Invalid label image type!";
     return false;
   }
 
@@ -90,8 +92,8 @@ bool maskInvalidSemantics(const cv::Mat& labels,
 
   for (int r = 0; r < labels.rows; ++r) {
     for (int c = 0; c < labels.cols; ++c) {
-      const auto label = labels.at<int32_t>(r, c);
-      mask.at<int32_t>(r, c) |= to_mask.count(label);
+      const auto label = labels.at<InputData::LabelType>(r, c);
+      mask.at<uint8_t>(r, c) |= to_mask.count(label);
     }
   }
 
@@ -105,7 +107,6 @@ bool maskNonZero(const cv::Mat input, cv::Mat& mask) {
 
   // if opencv implemented bitwise_or across integer types, we could just use that, but
   // this is likely more efficient than converting the entire input
-  // TODO(nathan) port to label remapper as well
   std::function<bool(const cv::Mat&, int, int)> input_getter;
   switch (input.depth()) {
     case CV_8U:
@@ -144,7 +145,7 @@ bool maskNonZero(const cv::Mat input, cv::Mat& mask) {
 
   for (int r = 0; r < input.rows; ++r) {
     for (int c = 0; c < input.cols; ++c) {
-      mask.at<int32_t>(r, c) |= input_getter(input, r, c);
+      mask.at<uint8_t>(r, c) |= input_getter(input, r, c);
     }
   }
 

--- a/src/reconstruction/projection_interpolators.cpp
+++ b/src/reconstruction/projection_interpolators.cpp
@@ -56,6 +56,8 @@
 #include <limits>
 #include <unordered_map>
 
+#include "hydra/input/input_data.h"
+
 namespace hydra {
 namespace {
 
@@ -98,18 +100,23 @@ Weights InterpolatorNearest::computeWeights(float u,
 
 float InterpolatorNearest::interpolateRange(const cv::Mat& range_image,
                                             const Weights& weights) const {
-  return range_image.at<float>(weights.v, weights.u);
+  return range_image.at<InputData::RangeType>(weights.v, weights.u);
 }
 
 Color InterpolatorNearest::interpolateColor(const cv::Mat& color_image,
                                             const Weights& weights) const {
-  const cv::Vec3b color = color_image.at<cv::Vec3b>(weights.v, weights.u);
+  const auto color = color_image.at<InputData::ColorType>(weights.v, weights.u);
   return Color(color[0], color[1], color[2]);
 }
 
 int InterpolatorNearest::interpolateID(const cv::Mat& id_image,
                                        const Weights& weights) const {
-  return id_image.at<int32_t>(weights.v, weights.u);
+  return id_image.at<InputData::LabelType>(weights.v, weights.u);
+}
+
+bool InterpolatorNearest::interpolateMask(const cv::Mat& mask_image,
+                                          const Weights& weights) const {
+  return mask_image.at<uint8_t>(weights.v, weights.u) > 0;
 }
 
 void declare_config(InterpolatorBilinear::Config&) {
@@ -138,19 +145,20 @@ Weights InterpolatorBilinear::computeWeights(float u,
 
 float InterpolatorBilinear::interpolateRange(const cv::Mat& range_image,
                                              const Weights& weights) const {
-  return range_image.at<float>(weights.v, weights.u) * weights.w0 +
-         range_image.at<float>(weights.v + 1, weights.u) * weights.w1 +
-         range_image.at<float>(weights.v, weights.u + 1) * weights.w2 +
-         range_image.at<float>(weights.v + 1, weights.u + 1) * weights.w3;
+  return range_image.at<InputData::RangeType>(weights.v, weights.u) * weights.w0 +
+         range_image.at<InputData::RangeType>(weights.v + 1, weights.u) * weights.w1 +
+         range_image.at<InputData::RangeType>(weights.v, weights.u + 1) * weights.w2 +
+         range_image.at<InputData::RangeType>(weights.v + 1, weights.u + 1) *
+             weights.w3;
 }
 
 Color InterpolatorBilinear::interpolateColor(const cv::Mat& color_image,
                                              const Weights& weights) const {
   Eigen::Vector3f color(0, 0, 0);
-  auto c1 = color_image.at<cv::Vec3b>(weights.v, weights.u);
-  auto c2 = color_image.at<cv::Vec3b>(weights.v + 1, weights.u);
-  auto c3 = color_image.at<cv::Vec3b>(weights.v, weights.u + 1);
-  auto c4 = color_image.at<cv::Vec3b>(weights.v + 1, weights.u + 1);
+  const auto c1 = color_image.at<InputData::ColorType>(weights.v, weights.u);
+  const auto c2 = color_image.at<InputData::ColorType>(weights.v + 1, weights.u);
+  const auto c3 = color_image.at<InputData::ColorType>(weights.v, weights.u + 1);
+  const auto c4 = color_image.at<InputData::ColorType>(weights.v + 1, weights.u + 1);
   for (size_t i = 0; i < 3; ++i) {
     color[i] = c1[i] * weights.w0 + c2[i] * weights.w1 + c3[i] * weights.w2 +
                c4[i] * weights.w3;
@@ -168,15 +176,25 @@ int InterpolatorBilinear::interpolateID(const cv::Mat& id_image,
   // TODO(nathan) consider manually implementing to avoid std::unordered_map memory
   // usage
   std::unordered_map<int, float> ids;  // These are zero initialized by default.
-  ids[id_image.at<int32_t>(weights.v, weights.u)] += weights.w0;
-  ids[id_image.at<int32_t>(weights.v + 1, weights.u)] += weights.w1;
-  ids[id_image.at<int32_t>(weights.v, weights.u + 1)] += weights.w2;
-  ids[id_image.at<int32_t>(weights.v + 1, weights.u + 1)] += weights.w3;
+  ids[id_image.at<InputData::LabelType>(weights.v, weights.u)] += weights.w0;
+  ids[id_image.at<InputData::LabelType>(weights.v + 1, weights.u)] += weights.w1;
+  ids[id_image.at<InputData::LabelType>(weights.v, weights.u + 1)] += weights.w2;
+  ids[id_image.at<InputData::LabelType>(weights.v + 1, weights.u + 1)] += weights.w3;
   return std::max_element(
              std::begin(ids),
              std::end(ids),
              [](const auto& p1, const auto& p2) { return p1.second < p2.second; })
       ->first;
+}
+
+bool InterpolatorBilinear::interpolateMask(const cv::Mat& img,
+                                           const Weights& weights) const {
+  float total = 0.0f;
+  total += img.at<uint8_t>(weights.v, weights.u) > 0 ? weights.w0 : -weights.w0;
+  total += img.at<uint8_t>(weights.v + 1, weights.u) > 0 ? weights.w1 : -weights.w1;
+  total += img.at<uint8_t>(weights.v, weights.u + 1) > 0 ? weights.w2 : -weights.w2;
+  total += img.at<uint8_t>(weights.v + 1, weights.u + 1) > 0 ? weights.w3 : -weights.w3;
+  return total >= 0.0f;  // will be negative if more weight on false
 }
 
 void declare_config(InterpolatorAdaptive::Config& config) {
@@ -205,7 +223,7 @@ Weights InterpolatorAdaptive::computeWeights(float u,
       continue;
     }
 
-    const float range = ranges.at<float>(curr_v, curr_u);
+    const float range = ranges.at<InputData::RangeType>(curr_v, curr_u);
     max = std::max(range, max);
     min = std::min(range, min);
     if (max - min > config.max_depth_difference_m) {
@@ -230,7 +248,7 @@ float InterpolatorAdaptive::interpolateRange(const cv::Mat& range_image,
     return InterpolatorBilinear::interpolateRange(range_image, weights);
   }
 
-  return range_image.at<float>(weights.v, weights.u);
+  return range_image.at<InputData::RangeType>(weights.v, weights.u);
 }
 
 Color InterpolatorAdaptive::interpolateColor(const cv::Mat& color_image,
@@ -239,7 +257,7 @@ Color InterpolatorAdaptive::interpolateColor(const cv::Mat& color_image,
     return InterpolatorBilinear::interpolateColor(color_image, weights);
   }
 
-  auto color = color_image.at<cv::Vec3b>(weights.v, weights.u);
+  auto color = color_image.at<InputData::ColorType>(weights.v, weights.u);
   return Color(color[0], color[1], color[2]);
 }
 
@@ -249,7 +267,16 @@ int InterpolatorAdaptive::interpolateID(const cv::Mat& id_image,
     return InterpolatorBilinear::interpolateID(id_image, weights);
   }
 
-  return id_image.at<int32_t>(weights.v, weights.u);
+  return id_image.at<InputData::LabelType>(weights.v, weights.u);
+}
+
+bool InterpolatorAdaptive::interpolateMask(const cv::Mat& img,
+                                           const Weights& weights) const {
+  if (weights.use_bilinear) {
+    return InterpolatorBilinear::interpolateMask(img, weights);
+  }
+
+  return img.at<uint8_t>(weights.v, weights.u) > 0;
 }
 
 }  // namespace hydra

--- a/src/reconstruction/projective_integrator.cpp
+++ b/src/reconstruction/projective_integrator.cpp
@@ -258,23 +258,21 @@ Measurement ProjectiveIntegrator::getVoxelMeasurement(const MapConfig& map_confi
 
 void ProjectiveIntegrator::updateVoxel(const MapConfig& map_config,
                                        const InputData& data,
-                                       const Measurement& measurement,
+                                       const Measurement& meas,
                                        VoxelTuple& voxels) const {
-  if (!std::isfinite(measurement.sdf)) {
+  if (!std::isfinite(meas.sdf)) {
     LOG(ERROR) << "found invalid measurement!";
     return;
   }
 
   // Cache old weight and add measurement to the current weight
-  auto& tsdf_voxel = *voxels.tsdf;
-  const auto prev_weight = tsdf_voxel.weight;
-  tsdf_voxel.weight =
-      std::min(tsdf_voxel.weight + measurement.weight, config.max_weight);
+  auto& tsdf = *voxels.tsdf;
+  const auto prev_weight = tsdf.weight;
+  tsdf.weight = std::min(tsdf.weight + meas.weight, config.max_weight);
 
   // Update TSDF distance using weighted averaging fusion
-  tsdf_voxel.distance =
-      (tsdf_voxel.distance * prev_weight + measurement.sdf * measurement.weight) /
-      (prev_weight + measurement.weight);
+  tsdf.distance = (tsdf.distance * prev_weight + meas.sdf * meas.weight) /
+                  (prev_weight + meas.weight);
 
   if (voxels.tracking) {
     // this condition should always trigger when the voxel has no integrated
@@ -286,21 +284,26 @@ void ProjectiveIntegrator::updateVoxel(const MapConfig& map_config,
   }
 
   // Don't bother updating colors or labels outside the truncation distance
-  if (measurementOutsideTruncation(map_config, config, measurement)) {
+  if (measurementOutsideTruncation(map_config, config, meas)) {
     return;
   }
 
-  // TODO(nathan) refactor into update functions
-  if (!data.color_image.empty()) {
-    const auto color = interpolator_->interpolateColor(
-        data.color_image, measurement.interpolation_weights);
-    const float ratio = measurement.weight / (tsdf_voxel.weight + measurement.weight);
-    tsdf_voxel.color.merge(color, ratio);
+  const auto& weights = meas.interpolation_weights;
+
+  bool valid_color = true;
+  if (!data.color_mask.empty() &&
+      !interpolator_->interpolateMask(data.color_mask, weights)) {
+    valid_color = false;  // disable color update when no color present
+  }
+
+  if (!data.color_image.empty() && valid_color) {
+    const auto color = interpolator_->interpolateColor(data.color_image, weights);
+    const float ratio = meas.weight / (tsdf.weight + meas.weight);
+    tsdf.color.merge(color, ratio);
   }
 
   if (semantic_integrator_ && voxels.semantic) {
-    semantic_integrator_->updateLikelihoods(
-        measurement.label, measurement.weight, *voxels.semantic);
+    semantic_integrator_->updateLikelihoods(meas.label, meas.weight, *voxels.semantic);
   }
 }
 

--- a/src/reconstruction/projective_integrator.cpp
+++ b/src/reconstruction/projective_integrator.cpp
@@ -382,7 +382,7 @@ float ProjectiveIntegrator::computeWeight(const MapConfig& map_config,
 
 bool ProjectiveIntegrator::computeLabel(const MapConfig& map_config,
                                         const InputData& data,
-                                        const cv::Mat& integration_mask,
+                                        const cv::Mat& mask,
                                         Measurement& measurement) const {
   if (measurementOutsideTruncation(map_config, config, measurement)) {
     return true;
@@ -390,9 +390,8 @@ bool ProjectiveIntegrator::computeLabel(const MapConfig& map_config,
 
   // the formatting here is a little ugly, but if an integration mask is supplied and it
   // is non-zero for the best pixel, we skip integrating the current voxel
-  if (!integration_mask.empty() &&
-      interpolator_->interpolateID(integration_mask,
-                                   measurement.interpolation_weights)) {
+  if (!mask.empty() &&
+      interpolator_->interpolateMask(mask, measurement.interpolation_weights)) {
     return false;
   }
 

--- a/tests/input/test_camera.cpp
+++ b/tests/input/test_camera.cpp
@@ -145,20 +145,20 @@ TEST(Camera, VertexMapAndRangeCorrect) {
 
   // x: 0 -> -1.5 / 1.5 = -1.0, x: 1 -> -0.5 / 1.5 = -1/3, x: 2 -> 0.5 / 1.5 = 1/3
   // y: 0 -> -1 / 1.0 = -1.0, y: 1 -> 0 / 1.0 = 0
-  cv::Mat expected_points(depth.size(), CV_32FC3);
-  cv::Mat expected_range(depth.size(), CV_32FC1);
-  expected_points.at<cv::Vec3f>(0, 0) = {-1.0f, -1.0f, 1.0f};
-  expected_range.at<float>(0, 0) = std::sqrt(3);
-  expected_points.at<cv::Vec3f>(0, 1) = {-2.0 / 3.0f, -2.0f, 2.0f};
-  expected_range.at<float>(0, 1) = 2.9059f;
-  expected_points.at<cv::Vec3f>(0, 2) = {1.0f, -3.0f, 3.0f};
-  expected_range.at<float>(0, 2) = 4.3589f;
-  expected_points.at<cv::Vec3f>(1, 0) = {-4.0f, 0.0f, 4.0f};
-  expected_range.at<float>(1, 0) = 5.6569f;
-  expected_points.at<cv::Vec3f>(1, 1) = {-5.0 / 3.0f, 0.0f, 5.0f};
-  expected_range.at<float>(1, 1) = 5.2605f;
-  expected_points.at<cv::Vec3f>(1, 2) = {2.0f, 0.0f, 6.0f};
-  expected_range.at<float>(1, 2) = 6.3245f;
+  cv::Mat expected_points(depth.size(), InputData::VertexMatType);
+  cv::Mat expected_range(depth.size(), InputData::RangeMatType);
+  expected_points.at<InputData::VertexType>(0, 0) = {-1.0f, -1.0f, 1.0f};
+  expected_range.at<InputData::RangeType>(0, 0) = std::sqrt(3);
+  expected_points.at<InputData::VertexType>(0, 1) = {-2.0 / 3.0f, -2.0f, 2.0f};
+  expected_range.at<InputData::RangeType>(0, 1) = 2.9059f;
+  expected_points.at<InputData::VertexType>(0, 2) = {1.0f, -3.0f, 3.0f};
+  expected_range.at<InputData::RangeType>(0, 2) = 4.3589f;
+  expected_points.at<InputData::VertexType>(1, 0) = {-4.0f, 0.0f, 4.0f};
+  expected_range.at<InputData::RangeType>(1, 0) = 5.6569f;
+  expected_points.at<InputData::VertexType>(1, 1) = {-5.0 / 3.0f, 0.0f, 5.0f};
+  expected_range.at<InputData::RangeType>(1, 1) = 5.2605f;
+  expected_points.at<InputData::VertexType>(1, 2) = {2.0f, 0.0f, 6.0f};
+  expected_range.at<InputData::RangeType>(1, 2) = 6.3245f;
 
   const auto result_points = camera->computeVertexMap(depth);
   float min_range = 0.0f;
@@ -176,9 +176,11 @@ TEST(Camera, VertexMapAndRangeCorrect) {
     for (int j = 0; j < result_points.cols; ++j) {
       SCOPED_TRACE("checking result @ [" + std::to_string(i) + ", " +
                    std::to_string(j) + "]");
-      EXPECT_NEAR(result_range.at<float>(i, j), expected_range.at<float>(i, j), 1.0e-2);
-      const auto expected_point = expected_points.at<cv::Vec3f>(i, j);
-      const auto result_point = result_points.at<cv::Vec3f>(i, j);
+      EXPECT_NEAR(result_range.at<InputData::RangeType>(i, j),
+                  expected_range.at<InputData::RangeType>(i, j),
+                  1.0e-2);
+      const auto expected_point = expected_points.at<InputData::VertexType>(i, j);
+      const auto result_point = result_points.at<InputData::VertexType>(i, j);
       EXPECT_NEAR(expected_point[0], result_point[0], 1.0e-5f);
       EXPECT_NEAR(expected_point[1], result_point[1], 1.0e-5f);
       EXPECT_NEAR(expected_point[2], result_point[2], 1.0e-5f);
@@ -204,10 +206,10 @@ TEST(Camera, FinalizeRepresentationsCorrect) {
 }
 
 TEST(Camera, RangeImageFromPointsCorrect) {
-  cv::Mat points(4, 3, CV_32FC3);
+  cv::Mat points(4, 3, InputData::VertexMatType);
   for (int r = 0; r < points.rows; ++r) {
     for (int c = 0; c < points.cols; ++c) {
-      auto& vec = points.at<cv::Vec3f>(r, c);
+      auto& vec = points.at<InputData::VertexType>(r, c);
       vec[0] = r * points.cols + c + 1;
       vec[1] = r * points.cols + c + 1;
       vec[2] = r * points.cols + c + 1;
@@ -223,7 +225,7 @@ TEST(Camera, RangeImageFromPointsCorrect) {
   ASSERT_EQ(range_image.cols, 3);
   for (int r = 0; r < points.rows; ++r) {
     for (int c = 0; c < points.cols; ++c) {
-      EXPECT_NEAR(range_image.at<float>(r, c),
+      EXPECT_NEAR(range_image.at<InputData::RangeType>(r, c),
                   std::sqrt(3.0) * (r * points.cols + c + 1),
                   1.0e-6);
     }

--- a/tests/input/test_lidar.cpp
+++ b/tests/input/test_lidar.cpp
@@ -75,30 +75,30 @@ TEST(Lidar, FinalizeRepresentationsCorrect) {
   // no points: no ability to make intermediate images
   EXPECT_FALSE(lidar->finalizeRepresentations(msg));
 
-  msg.vertex_map = cv::Mat(1, 2, CV_32FC3);
-  auto& v1 = msg.vertex_map.at<cv::Vec3f>(0, 0);
+  msg.vertex_map = cv::Mat(1, 2, InputData::VertexMatType);
+  auto& v1 = msg.vertex_map.at<InputData::VertexType>(0, 0);
   v1[0] = 3.0;
   v1[1] = 4.0;
   v1[2] = 0.0;
-  auto& v2 = msg.vertex_map.at<cv::Vec3f>(0, 1);
+  auto& v2 = msg.vertex_map.at<InputData::VertexType>(0, 1);
   v2[0] = 1.0;
   v2[1] = 0.0;
   v2[2] = 1.0;
 
   // invalid label size: no ability to make intermediate images
-  msg.label_image = cv::Mat(2, 1, CV_32SC1);
+  msg.label_image = cv::Mat(2, 1, InputData::LabelMatType);
   EXPECT_FALSE(lidar->finalizeRepresentations(msg));
 
   // invalid instance size: no ability to make intermediate images
   msg.label_image = cv::Mat();
-  msg.instance_image = cv::Mat(2, 1, CV_16SC1);
+  msg.instance_image = cv::Mat(2, 1, InputData::InstanceMatType);
   EXPECT_FALSE(lidar->finalizeRepresentations(msg));
 
-  msg.label_image = cv::Mat(1, 2, CV_32SC1);
+  msg.label_image = cv::Mat(1, 2, InputData::LabelMatType);
   msg.label_image.at<InputData::LabelType>(0, 0) = 1;
   msg.label_image.at<InputData::LabelType>(0, 1) = 2;
 
-  msg.instance_image = cv::Mat(1, 2, CV_16SC1);
+  msg.instance_image = cv::Mat(1, 2, InputData::InstanceMatType);
   msg.instance_image.at<InputData::InstanceType>(0, 0) = 3;
   msg.instance_image.at<InputData::InstanceType>(0, 1) = 4;
 
@@ -129,14 +129,14 @@ TEST(Lidar, FinalizeRepresentationsCorrect) {
       }
 
       SCOPED_TRACE("checking [" + std::to_string(r) + ", " + std::to_string(c) + "]");
-      EXPECT_NEAR(msg.range_image.at<float>(r, c), 0.0, 1.0e-3);
+      EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(r, c), 0.0, 1.0e-3);
       EXPECT_EQ(msg.label_image.at<InputData::LabelType>(r, c), -1);
       EXPECT_EQ(msg.instance_image.at<InputData::InstanceType>(r, c), 0);
     }
   }
 
-  EXPECT_NEAR(msg.range_image.at<float>(0, 320), std::sqrt(2.0f), 1.0e-5f);
-  EXPECT_NEAR(msg.range_image.at<float>(240, 131), 5.0f, 1.0e-5f);
+  EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(0, 320), std::sqrt(2.0f), 1.0e-5f);
+  EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(240, 131), 5.0f, 1.0e-5f);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(0, 320), 2);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(240, 131), 1);
   EXPECT_EQ(msg.instance_image.at<InputData::InstanceType>(0, 320), 4);
@@ -146,23 +146,23 @@ TEST(Lidar, FinalizeRepresentationsCorrect) {
 TEST(Lidar, FinalizeRepresentationColor) {
   const auto lidar = createLidar(90.0, 180.0, {1.0, 5.0});
   InputData msg(lidar);
-  msg.vertex_map = cv::Mat(1, 2, CV_32FC3);
-  auto& v1 = msg.vertex_map.at<cv::Vec3f>(0, 0);
+  msg.vertex_map = cv::Mat(1, 2, InputData::VertexMatType);
+  auto& v1 = msg.vertex_map.at<InputData::VertexType>(0, 0);
   v1[0] = 3.0;
   v1[1] = 4.0;
   v1[2] = 0.0;
-  auto& v2 = msg.vertex_map.at<cv::Vec3f>(0, 1);
+  auto& v2 = msg.vertex_map.at<InputData::VertexType>(0, 1);
   v2[0] = 1.0;
   v2[1] = 0.0;
   v2[2] = 1.0;
 
-  msg.label_image = cv::Mat(1, 2, CV_32SC1);
+  msg.label_image = cv::Mat(1, 2, InputData::LabelMatType);
   msg.label_image.at<InputData::LabelType>(0, 0) = 1;
   msg.label_image.at<InputData::LabelType>(0, 1) = 2;
 
-  msg.color_image = cv::Mat(1, 2, CV_8UC3);
-  msg.color_image.at<cv::Vec3b>(0, 0) = {1, 2, 3};
-  msg.color_image.at<cv::Vec3b>(0, 1) = {3, 4, 5};
+  msg.color_image = cv::Mat(1, 2, InputData::ColorMatType);
+  msg.color_image.at<InputData::ColorType>(0, 0) = {1, 2, 3};
+  msg.color_image.at<InputData::ColorType>(0, 1) = {3, 4, 5};
 
   EXPECT_TRUE(lidar->finalizeRepresentations(msg));
   ASSERT_EQ(msg.range_image.rows, 480);
@@ -175,14 +175,14 @@ TEST(Lidar, FinalizeRepresentationColor) {
   EXPECT_NEAR(msg.max_range, 5.0, 1.0e-6);
 
   const cv::Vec3b color1{3, 4, 5};
-  EXPECT_NEAR(msg.range_image.at<float>(0, 320), std::sqrt(2.0f), 1.0e-5f);
+  EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(0, 320), std::sqrt(2.0f), 1.0e-5f);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(0, 320), 2);
-  EXPECT_EQ(msg.color_image.at<cv::Vec3b>(0, 320), color1);
+  EXPECT_EQ(msg.color_image.at<InputData::ColorType>(0, 320), color1);
 
   const cv::Vec3b color2{1, 2, 3};
-  EXPECT_NEAR(msg.range_image.at<float>(240, 131), 5.0f, 1.0e-5f);
+  EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(240, 131), 5.0f, 1.0e-5f);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(240, 131), 1);
-  EXPECT_EQ(msg.color_image.at<cv::Vec3b>(240, 131), color2);
+  EXPECT_EQ(msg.color_image.at<InputData::ColorType>(240, 131), color2);
 }
 
 TEST(Lidar, ImagePlaneProjectionCorrect) {

--- a/tests/input/test_lidar.cpp
+++ b/tests/input/test_lidar.cpp
@@ -135,7 +135,8 @@ TEST(Lidar, FinalizeRepresentationsCorrect) {
     }
   }
 
-  EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(0, 320), std::sqrt(2.0f), 1.0e-5f);
+  EXPECT_NEAR(
+      msg.range_image.at<InputData::RangeType>(0, 320), std::sqrt(2.0f), 1.0e-5f);
   EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(240, 131), 5.0f, 1.0e-5f);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(0, 320), 2);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(240, 131), 1);
@@ -175,7 +176,8 @@ TEST(Lidar, FinalizeRepresentationColor) {
   EXPECT_NEAR(msg.max_range, 5.0, 1.0e-6);
 
   const cv::Vec3b color1{3, 4, 5};
-  EXPECT_NEAR(msg.range_image.at<InputData::RangeType>(0, 320), std::sqrt(2.0f), 1.0e-5f);
+  EXPECT_NEAR(
+      msg.range_image.at<InputData::RangeType>(0, 320), std::sqrt(2.0f), 1.0e-5f);
   EXPECT_EQ(msg.label_image.at<InputData::LabelType>(0, 320), 2);
   EXPECT_EQ(msg.color_image.at<InputData::ColorType>(0, 320), color1);
 

--- a/tests/reconstruction/test_integration_masking.cpp
+++ b/tests/reconstruction/test_integration_masking.cpp
@@ -33,6 +33,7 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
+#include <hydra/input/input_data.h>
 #include <hydra/reconstruction/integration_masking.h>
 
 #include <opencv2/core.hpp>
@@ -53,7 +54,6 @@ TEST(IntegrationMasking, InitCorrect) {
     EXPECT_TRUE(maskNonZero(input, mask));
     EXPECT_EQ(mask.rows, 4);
     EXPECT_EQ(mask.cols, 3);
-    EXPECT_EQ(mask.type(), CV_32SC1);
   }
 
   {  // mismatch -> no masking performed
@@ -62,16 +62,15 @@ TEST(IntegrationMasking, InitCorrect) {
     EXPECT_FALSE(maskNonZero(input, mask));
     EXPECT_EQ(mask.rows, 3);
     EXPECT_EQ(mask.cols, 4);
-    EXPECT_EQ(mask.type(), CV_32SC1);
   }
 
   {  // non-int32_t type -> conversion happens
     cv::Mat input = cv::Mat::zeros(4, 3, CV_8UC1);
-    cv::Mat mask(4, 3, CV_8UC1);
+    cv::Mat mask(4, 3, CV_32SC1);
     EXPECT_TRUE(maskNonZero(input, mask));
     EXPECT_EQ(mask.rows, 4);
     EXPECT_EQ(mask.cols, 3);
-    EXPECT_EQ(mask.type(), CV_32SC1);
+    EXPECT_EQ(mask.type(), CV_8UC1);
   }
 }
 
@@ -79,15 +78,15 @@ TEST(IntegrationMasking, SemanticsCorrect) {
   {  // empty labels, empty mask
     cv::Mat labels;
     cv::Mat mask;
-    std::set<int32_t> to_mask{1, 2, 3};
+    std::set<InputData::LabelType> to_mask{1, 2, 3};
     EXPECT_TRUE(maskInvalidSemantics(labels, to_mask, mask));
     EXPECT_TRUE(mask.empty());
   }
 
   {  // no labels to mask, empty mask
-    cv::Mat labels = cv::Mat::zeros(4, 3, CV_32SC1);
+    cv::Mat labels = cv::Mat::zeros(4, 3, InputData::LabelMatType);
     cv::Mat mask;
-    std::set<int32_t> to_mask;
+    std::set<InputData::LabelType> to_mask;
     EXPECT_TRUE(maskInvalidSemantics(labels, to_mask, mask));
     EXPECT_TRUE(mask.empty());
   }
@@ -95,30 +94,30 @@ TEST(IntegrationMasking, SemanticsCorrect) {
   {  // invalid label image, empty mask
     cv::Mat labels = cv::Mat::zeros(4, 3, CV_8UC1);
     cv::Mat mask;
-    std::set<int32_t> to_mask{1, 2, 3};
+    std::set<InputData::LabelType> to_mask{1, 2, 3};
     EXPECT_FALSE(maskInvalidSemantics(labels, to_mask, mask));
     EXPECT_TRUE(mask.empty());
   }
 
   {  // valid input -> correct output
-    cv::Mat labels = cv::Mat::zeros(4, 3, CV_32SC1);
-    labels.at<int32_t>(0, 1) = 1;
-    labels.at<int32_t>(1, 2) = 2;
-    labels.at<int32_t>(2, 1) = 4;
-    labels.at<int32_t>(3, 2) = 3;
+    cv::Mat labels = cv::Mat::zeros(4, 3, InputData::LabelMatType);
+    labels.at<InputData::LabelType>(0, 1) = 1;
+    labels.at<InputData::LabelType>(1, 2) = 2;
+    labels.at<InputData::LabelType>(2, 1) = 4;
+    labels.at<InputData::LabelType>(3, 2) = 3;
 
     cv::Mat mask;
-    std::set<int32_t> to_mask{1, 2, 3};
+    std::set<InputData::LabelType> to_mask{1, 2, 3};
     EXPECT_TRUE(maskInvalidSemantics(labels, to_mask, mask));
     EXPECT_EQ(cv::countNonZero(mask), 3);
-    EXPECT_EQ(mask.at<int32_t>(0, 1), 1);
-    EXPECT_EQ(mask.at<int32_t>(1, 2), 1);
-    EXPECT_EQ(mask.at<int32_t>(3, 2), 1);
+    EXPECT_EQ(mask.at<uint8_t>(0, 1), 1);
+    EXPECT_EQ(mask.at<uint8_t>(1, 2), 1);
+    EXPECT_EQ(mask.at<uint8_t>(3, 2), 1);
   }
 }
 
 TEST(IntegrationMasking, NonZeroCorrect) {
-  {  // non integer model, empty mask
+  {  // non integer input, empty mask
     cv::Mat input = cv::Mat::zeros(4, 3, CV_32FC1);
     cv::Mat mask;
     EXPECT_FALSE(maskNonZero(input, mask));
@@ -135,10 +134,10 @@ TEST(IntegrationMasking, NonZeroCorrect) {
     cv::Mat mask;
     EXPECT_TRUE(maskNonZero(input, mask));
     EXPECT_EQ(cv::countNonZero(mask), 4);
-    EXPECT_EQ(mask.at<int32_t>(0, 1), 1);
-    EXPECT_EQ(mask.at<int32_t>(1, 2), 1);
-    EXPECT_EQ(mask.at<int32_t>(2, 1), 1);
-    EXPECT_EQ(mask.at<int32_t>(3, 2), 1);
+    EXPECT_EQ(mask.at<uint8_t>(0, 1), 1);
+    EXPECT_EQ(mask.at<uint8_t>(1, 2), 1);
+    EXPECT_EQ(mask.at<uint8_t>(2, 1), 1);
+    EXPECT_EQ(mask.at<uint8_t>(3, 2), 1);
   }
 }
 


### PR DESCRIPTION
Changes:
- Updates OpenCV access to use typedefs from `InputData` where applicable
- Adds a "color mask" to the input data that identifies whether or not the color is valid to be integrated and updates the projective integrator to not blend invalid colors
- Adds small camera helper