### PR TITLE
add range validity checks to interpolator weight computation

### DIFF
--- a/hydra/include/hydra/reconstruction/projection_interpolators.h
+++ b/hydra/include/hydra/reconstruction/projection_interpolators.h
@@ -171,6 +171,9 @@ class InterpolatorBilinear : public ProjectionInterpolator {
 
   bool interpolateMask(const cv::Mat& mask_image,
                        const InterpolationWeights& weights) const override;
+
+ protected:
+  void fillBilinearWeights(float u, float v, InterpolationWeights& weights) const;
 };
 
 void declare_config(InterpolatorBilinear::Config& config);

--- a/hydra/src/reconstruction/projection_interpolators.cpp
+++ b/hydra/src/reconstruction/projection_interpolators.cpp
@@ -59,6 +59,10 @@
 #include "hydra/input/input_data.h"
 
 namespace hydra {
+
+using spark_dsg::Color;
+using Weights = InterpolationWeights;
+
 namespace {
 
 static const auto nearest_registration =
@@ -76,10 +80,23 @@ static const auto adaptive_registration =
                                    InterpolatorAdaptive,
                                    InterpolatorAdaptive::Config>("adaptive");
 
-}  // namespace
+inline bool pixelIsValid(int u, int v, const cv::Mat& img) {
+  const auto range = img.at<InputData::RangeType>(v, u);
+  return range >= 1.0e-6f && std::isfinite(range);
+}
 
-using spark_dsg::Color;
-using Weights = InterpolationWeights;
+inline Weights getNearestWeights(float u, float v, const cv::Mat& img) {
+  Weights weights(std::round(u), std::round(v));
+  if (weights.u < 0 || weights.u >= img.cols || weights.v < 0 ||
+      weights.v >= img.rows) {
+    return weights;
+  }
+
+  weights.valid = pixelIsValid(weights.u, weights.v, img);
+  return weights;
+}
+
+}  // namespace
 
 void declare_config(InterpolatorNearest::Config&) {
   config::name("InterpolatorNearest::Config");
@@ -88,14 +105,7 @@ void declare_config(InterpolatorNearest::Config&) {
 Weights InterpolatorNearest::computeWeights(float u,
                                             float v,
                                             const cv::Mat& img) const {
-  Weights weights(std::round(u), std::round(v));
-  if (weights.u < 0 || weights.u >= img.cols || weights.v < 0 ||
-      weights.v >= img.rows) {
-    return weights;
-  }
-
-  weights.valid = true;
-  return weights;
+  return getNearestWeights(u, v, img);
 }
 
 float InterpolatorNearest::interpolateRange(const cv::Mat& range_image,
@@ -132,14 +142,16 @@ Weights InterpolatorBilinear::computeWeights(float u,
     return weights;
   }
 
-  weights.valid = true;
-  weights.use_bilinear = true;
-  float du = u - static_cast<float>(weights.u);
-  float dv = v - static_cast<float>(weights.v);
-  weights.w0 = (1.f - du) * (1.f - dv);
-  weights.w1 = (1.f - du) * dv;
-  weights.w2 = du * (1.f - dv);
-  weights.w3 = du * dv;
+  // all range values in 2x2 grid must be finite for bilinear interpolation to work
+  weights.valid = pixelIsValid(weights.u, weights.v, img);
+  weights.valid &= pixelIsValid(weights.u + 1, weights.v, img);
+  weights.valid &= pixelIsValid(weights.u, weights.v + 1, img);
+  weights.valid &= pixelIsValid(weights.u + 1, weights.v + 1, img);
+  if (!weights.valid) {
+    return weights;
+  }
+
+  fillBilinearWeights(u, v, weights);
   return weights;
 }
 
@@ -197,6 +209,19 @@ bool InterpolatorBilinear::interpolateMask(const cv::Mat& img,
   return total >= 0.0f;  // will be negative if more weight on false
 }
 
+void InterpolatorBilinear::fillBilinearWeights(float u,
+                                               float v,
+                                               Weights& weights) const {
+  const auto du = u - static_cast<float>(weights.u);
+  const auto dv = v - static_cast<float>(weights.v);
+
+  weights.use_bilinear = true;
+  weights.w0 = (1.0f - du) * (1.0f - dv);
+  weights.w1 = (1.0f - du) * dv;
+  weights.w2 = du * (1.0f - dv);
+  weights.w3 = du * dv;
+}
+
 void declare_config(InterpolatorAdaptive::Config& config) {
   using namespace config;
   config::name("InterpolatorAdaptive::Config");
@@ -211,35 +236,44 @@ InterpolatorAdaptive::InterpolatorAdaptive(const Config& config)
 Weights InterpolatorAdaptive::computeWeights(float u,
                                              float v,
                                              const cv::Mat& ranges) const {
-  Weights weights(std::floor(u), std::floor(v));
+  const int row = std::floor(v);
+  const int col = std::floor(u);
+
   // Check max range difference.
   bool use_nearest = false;
   float min = std::numeric_limits<float>::max();
-  float max = std::numeric_limits<float>::lowest();
+  float max = 0.0f;
   for (size_t i = 0; i < 4; ++i) {
-    const auto curr_v = weights.v + v_offset_[i];
-    const auto curr_u = weights.u + u_offset_[i];
+    const auto curr_v = row + v_offset_[i];
+    const auto curr_u = col + u_offset_[i];
     if (curr_v < 0 || curr_u < 0 || curr_v >= ranges.rows || curr_u >= ranges.cols) {
-      continue;
+      use_nearest = true;  // use nearest when at corner of imaage
+      break;
     }
 
     const float range = ranges.at<InputData::RangeType>(curr_v, curr_u);
+    if (range < 1.0e-6f || !std::isfinite(range)) {
+      use_nearest = true;  // use nearest when one pixel is invalid
+      break;
+    }
+
     max = std::max(range, max);
     min = std::min(range, min);
     if (max - min > config.max_depth_difference_m) {
-      use_nearest = true;
+      use_nearest = true;  // use nearest when adaptive check is hit
       break;
     }
   }
 
   if (use_nearest) {
-    Weights weights(std::round(u), std::round(v));
-    weights.valid = weights.u >= 0 && weights.u < ranges.cols && weights.v >= 0 &&
-                    weights.v < ranges.rows;
-    return weights;
+    // will handle validating pixel at [u, v]
+    return getNearestWeights(u, v, ranges);
   }
 
-  return InterpolatorBilinear::computeWeights(u, v, ranges);
+  Weights weights(col, row);
+  weights.valid = true;
+  fillBilinearWeights(u, v, weights);
+  return weights;
 }
 
 float InterpolatorAdaptive::interpolateRange(const cv::Mat& range_image,

--- a/hydra/src/reconstruction/projection_interpolators.cpp
+++ b/hydra/src/reconstruction/projection_interpolators.cpp
@@ -54,7 +54,6 @@
 #include <Eigen/Core>
 #include <cmath>
 #include <limits>
-#include <unordered_map>
 
 #include "hydra/input/input_data.h"
 
@@ -94,6 +93,25 @@ inline Weights getNearestWeights(float u, float v, const cv::Mat& img) {
 
   weights.valid = pixelIsValid(weights.u, weights.v, img);
   return weights;
+}
+
+inline void updateConfidences(InputData::LabelType label,
+                              float weight,
+                              std::array<int, 4>& ids,
+                              std::array<float, 4>& confidences,
+                              size_t& allocated) {
+  for (size_t i = 0; i < allocated; ++i) {
+    if (ids[i] == label) {
+      // increment already seen label and return
+      confidences[i] += weight;
+      return;
+    }
+  }
+
+  // fill new slot with label and weight
+  ids[allocated] = label;
+  confidences[allocated] = weight;
+  ++allocated;
 }
 
 }  // namespace
@@ -183,20 +201,39 @@ int InterpolatorBilinear::interpolateID(const cv::Mat& id_image,
                                         const Weights& weights) const {
   // Since IDs can not be interpolated we assign weights to all IDs in the image
   // based on the corner weights and return the highest weights ID.
-  // NOTE(nathan) this is not the same as just picking the maximum weight from the
-  // pixels
-  // TODO(nathan) consider manually implementing to avoid std::unordered_map memory
-  // usage
-  std::unordered_map<int, float> ids;  // These are zero initialized by default.
-  ids[id_image.at<InputData::LabelType>(weights.v, weights.u)] += weights.w0;
-  ids[id_image.at<InputData::LabelType>(weights.v + 1, weights.u)] += weights.w1;
-  ids[id_image.at<InputData::LabelType>(weights.v, weights.u + 1)] += weights.w2;
-  ids[id_image.at<InputData::LabelType>(weights.v + 1, weights.u + 1)] += weights.w3;
-  return std::max_element(
-             std::begin(ids),
-             std::end(ids),
-             [](const auto& p1, const auto& p2) { return p1.second < p2.second; })
-      ->first;
+
+  // first pixel will always be allocated
+  size_t allocated = 1;
+  std::array<int, 4> ids{
+      id_image.at<InputData::LabelType>(weights.v, weights.u), 0, 0, 0};
+  std::array<float, 4> confidences{weights.w0, 0.0f, 0.0f, 0.0f};
+
+  updateConfidences(id_image.at<InputData::LabelType>(weights.v + 1, weights.u),
+                    weights.w1,
+                    ids,
+                    confidences,
+                    allocated);
+  updateConfidences(id_image.at<InputData::LabelType>(weights.v, weights.u + 1),
+                    weights.w2,
+                    ids,
+                    confidences,
+                    allocated);
+  updateConfidences(id_image.at<InputData::LabelType>(weights.v + 1, weights.u + 1),
+                    weights.w3,
+                    ids,
+                    confidences,
+                    allocated);
+
+  float best_confidence = confidences[0];
+  InputData::LabelType best_id = ids[0];
+  for (size_t i = 1; i < allocated; ++i) {
+    if (confidences[i] > best_confidence) {
+      best_confidence = confidences[i];
+      best_id = ids[i];
+    }
+  }
+
+  return best_id;
 }
 
 bool InterpolatorBilinear::interpolateMask(const cv::Mat& img,

--- a/hydra/tests/reconstruction/test_projection_interpolators.cpp
+++ b/hydra/tests/reconstruction/test_projection_interpolators.cpp
@@ -38,6 +38,9 @@
 #include <opencv2/core.hpp>
 
 namespace hydra {
+
+using spark_dsg::Color;
+
 namespace {
 
 std::optional<float> getRange(const ProjectionInterpolator& interp,
@@ -50,6 +53,45 @@ std::optional<float> getRange(const ProjectionInterpolator& interp,
   }
 
   return interp.interpolateRange(mat, weights);
+}
+
+std::optional<Color> getColor(const ProjectionInterpolator& interp,
+                              const cv::Mat& ranges,
+                              const cv::Mat& colors,
+                              float u,
+                              float v) {
+  const auto weights = interp.computeWeights(u, v, ranges);
+  if (!weights.valid) {
+    return std::nullopt;
+  }
+
+  return interp.interpolateColor(colors, weights);
+}
+
+std::optional<int> getId(const ProjectionInterpolator& interp,
+                         const cv::Mat& ranges,
+                         const cv::Mat& ids,
+                         float u,
+                         float v) {
+  const auto weights = interp.computeWeights(u, v, ranges);
+  if (!weights.valid) {
+    return std::nullopt;
+  }
+
+  return interp.interpolateID(ids, weights);
+}
+
+std::optional<bool> getMask(const ProjectionInterpolator& interp,
+                            const cv::Mat& ranges,
+                            const cv::Mat& mask,
+                            float u,
+                            float v) {
+  const auto weights = interp.computeWeights(u, v, ranges);
+  if (!weights.valid) {
+    return std::nullopt;
+  }
+
+  return interp.interpolateMask(mask, weights);
 }
 
 }  // namespace
@@ -82,6 +124,43 @@ TEST(ProjectionInterpolators, NearestCorrect) {
   }
 }
 
+TEST(ProjectionInterpolators, NearestInvalidRangeCorrect) {
+  InterpolatorNearest interp;
+  cv::Mat img = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+
+  // setup invalid range values
+  img.at<float>(0, 1) = std::numeric_limits<float>::quiet_NaN();
+  img.at<float>(1, 0) = 0.0f;
+  img.at<float>(1, 1) = std::numeric_limits<float>::infinity();
+
+  ASSERT_TRUE(getRange(interp, img, 0.2, 0.2));
+  ASSERT_FALSE(getRange(interp, img, 1.2, 0.2));
+  ASSERT_FALSE(getRange(interp, img, 0.2, 1.2));
+  ASSERT_FALSE(getRange(interp, img, 1.2, 1.2));
+}
+
+TEST(ProjectionInterpolators, NearestCorrectNonRange) {
+  InterpolatorNearest interp;
+  cv::Mat ranges = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+  cv::Mat colors = (cv::Mat_<cv::Vec3b>(2, 2) << cv::Vec3b(1, 2, 3),
+                    cv::Vec3b(2, 3, 4),
+                    cv::Vec3b(3, 4, 5),
+                    cv::Vec3b(4, 5, 6));
+  cv::Mat ids = (cv::Mat_<int>(2, 2) << 1, 2, 3, 1);
+  cv::Mat mask = (cv::Mat_<bool>(2, 2) << false, true, false, true);
+
+  {  // outside of image
+    const auto color = getColor(interp, ranges, colors, 0.2, 0.4);
+    EXPECT_EQ(color, Color(1, 2, 3));
+
+    const auto id = getId(interp, ranges, ids, 0.2, 0.4);
+    EXPECT_EQ(id, 1);
+
+    const auto flag = getMask(interp, ranges, mask, 0.2, 0.4);
+    EXPECT_EQ(flag, false);
+  }
+}
+
 TEST(ProjectionInterpolators, BilinearCorrect) {
   InterpolatorBilinear interp;
   cv::Mat img = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
@@ -101,6 +180,48 @@ TEST(ProjectionInterpolators, BilinearCorrect) {
     const auto range = getRange(interp, img, 0.5, 0.0);
     ASSERT_TRUE(range);
     EXPECT_EQ(range.value(), 1.5f);
+  }
+}
+
+TEST(ProjectionInterpolators, BilinearInvalidRangeCorrect) {
+  InterpolatorBilinear interp;
+  cv::Mat img = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+  ASSERT_TRUE(getRange(interp, img, 0.0, 0.5));
+
+  // NaNs should disable interpolation
+  img.at<float>(0, 1) = std::numeric_limits<float>::quiet_NaN();
+  ASSERT_FALSE(getRange(interp, img, 0.0, 0.5));
+
+  // 0 depth should also be invalid
+  img.at<float>(0, 1) = 2.0;
+  img.at<float>(1, 0) = 0.0f;
+  ASSERT_FALSE(getRange(interp, img, 0.0, 0.5));
+
+  // infinite depth is also invalid
+  img.at<float>(1, 0) = 3.0;
+  img.at<float>(0, 0) = std::numeric_limits<float>::infinity();
+  ASSERT_FALSE(getRange(interp, img, 0.0, 0.5));
+}
+
+TEST(ProjectionInterpolators, BilinearCorrectNonRange) {
+  InterpolatorBilinear interp;
+  cv::Mat ranges = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+  cv::Mat colors = (cv::Mat_<cv::Vec3b>(2, 2) << cv::Vec3b(1, 2, 3),
+                    cv::Vec3b(2, 3, 4),
+                    cv::Vec3b(3, 4, 5),
+                    cv::Vec3b(4, 5, 6));
+  cv::Mat ids = (cv::Mat_<int>(2, 2) << 1, 1, 3, 1);
+  cv::Mat mask = (cv::Mat_<bool>(2, 2) << false, true, false, true);
+
+  {  // outside of image
+    const auto color = getColor(interp, ranges, colors, 0.0, 0.5);
+    EXPECT_EQ(color, Color(2, 3, 4));
+
+    const auto id = getId(interp, ranges, ids, 0.5, 0.0);
+    EXPECT_EQ(id, 1);
+
+    const auto flag = getMask(interp, ranges, mask, 0.7, 0.5);
+    EXPECT_EQ(flag, true);
   }
 }
 
@@ -133,6 +254,74 @@ TEST(ProjectionInterpolators, AdaptiveCorrect) {
     EXPECT_NEAR(range_bilinear.value(), 1.5f, 1.0e-3f);
     EXPECT_NEAR(range_nearest.value(), 2.0f, 1.0e-3f);
   }
+}
+
+TEST(ProjectionInterpolators, AdaptiveCorrectNonRange) {
+  // check that bilinear values match
+  cv::Mat ranges = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+  cv::Mat colors = (cv::Mat_<cv::Vec3b>(2, 2) << cv::Vec3b(1, 2, 3),
+                    cv::Vec3b(2, 3, 4),
+                    cv::Vec3b(3, 4, 5),
+                    cv::Vec3b(4, 5, 6));
+  cv::Mat ids = (cv::Mat_<int>(2, 2) << 1, 1, 3, 1);
+  cv::Mat mask = (cv::Mat_<bool>(2, 2) << false, true, false, true);
+
+  {  // bilinear interpolation results
+    InterpolatorAdaptive interp(InterpolatorAdaptive::Config{3.5});
+    const auto color = getColor(interp, ranges, colors, 0.0, 0.5);
+    EXPECT_EQ(color, Color(2, 3, 4));
+
+    const auto id = getId(interp, ranges, ids, 0.5, 0.0);
+    EXPECT_EQ(id, 1);
+
+    const auto flag = getMask(interp, ranges, mask, 0.7, 0.5);
+    EXPECT_EQ(flag, true);
+  }
+
+  {  // nearest interpolation results
+    InterpolatorAdaptive interp(InterpolatorAdaptive::Config{0.2});
+
+    const auto color = getColor(interp, ranges, colors, 0.0, 0.6);
+    EXPECT_EQ(color, Color(3, 4, 5));
+
+    const auto id = getId(interp, ranges, ids, 0.6, 0.0);
+    EXPECT_EQ(id, 1);
+
+    const auto flag = getMask(interp, ranges, mask, 0.7, 0.51);
+    EXPECT_EQ(flag, true);
+  }
+}
+
+TEST(ProjectionInterpolators, AdaptiveCorrectInvalidRange) {
+  cv::Mat ranges = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+
+  InterpolatorAdaptive interp(InterpolatorAdaptive::Config{3.5});
+  ASSERT_TRUE(getRange(interp, ranges, 0.3, 0.4));
+
+  ranges.at<float>(0, 0) = 0.0;
+  ASSERT_FALSE(getRange(interp, ranges, 0.3, 0.4));
+  ASSERT_TRUE(getRange(interp, ranges, 0.6, 0.4));
+
+  ranges.at<float>(0, 0) = 1.0;
+  ranges.at<float>(0, 1) = std::numeric_limits<float>::quiet_NaN();
+  ASSERT_TRUE(getRange(interp, ranges, 0.3, 0.4));
+  ASSERT_FALSE(getRange(interp, ranges, 0.6, 0.4));
+}
+
+TEST(ProjectionInterpolators, LabelVotingCorrect) {
+  cv::Mat ranges = (cv::Mat_<float>(2, 2) << 1.0, 2.0, 3.0, 4.0);
+
+  InterpolatorBilinear interp;
+  cv::Mat ids = (cv::Mat_<int>(2, 2) << 2, 1, 3, 1);
+
+  // voting should pick 2 (row 1 has no weight)
+  EXPECT_EQ(getId(interp, ranges, ids, 0.4, 0.0), 2);
+
+  // voting should pick 1 (equal weight between rows)
+  EXPECT_EQ(getId(interp, ranges, ids, 0.4, 0.5), 1);
+
+  // voting should pick 3 (row 0 has no weight)
+  EXPECT_EQ(getId(interp, ranges, ids, 0.4, 0.99), 3);
 }
 
 TEST(ProjectionInterpolators, AdaptiveOutOfRange) {

--- a/hydra_ros/app/hydra_node.cpp
+++ b/hydra_ros/app/hydra_node.cpp
@@ -148,7 +148,7 @@ int main(int argc, char* argv[]) {
   {  // start hydra scope
     std::vector<std::unique_ptr<hydra::AppPlugin>> node_plugins;
     for (const auto& plugin : settings.node_plugins) {
-      node_plugins.push_back(plugin.create(nh));
+      node_plugins.push_back(plugin.create());
     }
 
     hydra::GlobalInfo::instance().setForceShutdown(settings.force_shutdown);


### PR DESCRIPTION
Fixes issues where invalid range values are treated as valid pixels. Actual changes:
- Interpolation weights in the projective integrator are not considered valid unless all relevant range values are non-zero and finite (either nearest pixel or surrounding 2x2 group of pixels)
- Adaptive interpolator now falls back to nearest interpolation if the billinear interpolation would be invalid